### PR TITLE
wrap rightsdeclaration descriptivenote examples in <ead:p> tags

### DIFF
--- a/tei/EAD3-TL-eng.xml
+++ b/tei/EAD3-TL-eng.xml
@@ -4588,7 +4588,7 @@
                      <ead:rightsdeclaration>
                         <ead:abbr>CC0</ead:abbr>
                         <ead:citation href="https://creativecommons.org/publicdomain/zero/1.0/"/>
-                        <ead:descriptivenote>CC0 1.0 Universal (CC0 1.0)</ead:descriptivenote>
+                        <ead:descriptivenote><ead:p>CC0 1.0 Universal (CC0 1.0)</ead:p></ead:descriptivenote>
                      </ead:rightsdeclaration>
                   </egXML>
                </div>
@@ -13001,7 +13001,7 @@
                         <ead:rightsdeclaration>
                            <ead:abbr>CC0</ead:abbr>
                            <ead:citation href="https://creativecommons.org/publicdomain/zero/1.0/"/>
-                           <ead:descriptivenote>CC0 1.0 Universal (CC0 1.0)</ead:descriptivenote>
+                           <ead:descriptivenote><ead:p>CC0 1.0 Universal (CC0 1.0)</ead:p></ead:descriptivenote>
                         </ead:rightsdeclaration>
                      </ead:control>
                   </egXML>


### PR DESCRIPTION
Fixing the `<descriptivenote>` examples within `<rightsdeclaration>` by wrapping child text in `<ead:p>` tags, as per #17 .