### PR TITLE
adding support for SAA logo flag to build script

### DIFF
--- a/build/generate_tag_libraries.bat
+++ b/build/generate_tag_libraries.bat
@@ -3,7 +3,6 @@
 :: check if Java is installed
 java -version
 if %ERRORLEVEL% NEQ 0 GOTO NOJAVA
-goto STARTUP
 
 :: check if the TEI file exists
 if not exist %2 ( goto NOFILE )
@@ -15,18 +14,23 @@ if /i %1 == premis ( goto PREMIS )
 echo syntax: generate_tag_libraries.bat (eac ead premis) path\to\tei.xml
 goto END
 
-:: if we want to pass config variables to the XSLT, we can do it via these functions
-:: there's nothing here right now, but very likely will be soon!
+:: run XSLT transformations via Saxon, passing standard-specific variables to the XSLT via these commands
 :EAC
 echo Generating EAC-CPF tag libraries
+java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2html.xsl -o:%1.html SAA="yes"
+java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2pdf.xsl -o:%1.xml SAA="yes"
 goto MAIN
 
 :EAD
 echo Generating EAD tag libraries
+java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2html.xsl -o:%1.html SAA="yes"
+java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2pdf.xsl -o:%1.xml SAA="yes"
 goto MAIN
 
 :PREMIS
 echo Generating PREMIS tag libraries
+java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2html.xsl -o:%1.html SAA="no"
+java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2pdf.xsl -o:%1.xml SAA="no"
 goto MAIN
 
 :: error out if Java is not installed
@@ -45,8 +49,6 @@ GOTO END
 :: run fop on the FOXML...I don't know how to remove the temp XML,
 :: since fop.bat closes out of the script!
 :MAIN
-java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2html.xsl -o:%1.html
-java -cp vendor\SaxonHE10-2J\saxon-he-10.2.jar net.sf.saxon.Transform -s:%2 -xsl:..\transformations\tagLibrary2pdf.xsl -o:%1.xml
 vendor\fop-2.5\fop\fop.bat %1.xml %1.pdf
 GOTO END
 

--- a/build/generate_tag_libraries.sh
+++ b/build/generate_tag_libraries.sh
@@ -14,35 +14,37 @@ then
     exit 1
 fi
 
+# paths to libraries
+saxon="vendor/SaxonHE10-2J/saxon-he-10.2.jar"
+fop="vendor/fop-2.5/fop/fop"
+outfile=$(basename "$2" .xml)
+
 # check for which TL we're generating
-# if we want to pass any standard-specific variables in,
-# we would do it here (e.g. no SAA logo for PREMIS)
+# and generate the FOXML+HTML with parameters based on that
+# e.g. PREMIS doesn't get the SAA logo on the cover
 case $1 in
 	"eac")
 		echo "generating EAC-CPF tag libraries"
+		java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2pdf.xsl -o:"$outfile"-tmp.xml SAA="yes"
+		java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2html.xsl -o:"$outfile".html SAA="yes"
 		;;
 	"ead")
 		echo "generating EAD3 tag libraries"
+		java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2pdf.xsl -o:"$outfile"-tmp.xml SAA="yes"
+		java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2html.xsl -o:"$outfile".html SAA="yes"
 		;;
 	"premis")
 		echo "generating PREMIS tag libraries"
+		java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2pdf.xsl -o:"$outfile"-tmp.xml SAA="no"
+		java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2html.xsl -o:"$outfile".html SAA="no"
 		;;
 	*)
 		echo "supplied tag library must be: eac, ead, premis"
 		exit 1
 esac
 
-# paths to libraries
-saxon="vendor/SaxonHE10-2J/saxon-he-10.2.jar"
-fop="vendor/fop-2.5/fop/fop"
-outfile=$(basename "$2" .xml)
-
-# generate the FOXML, then FOXML->PDF, then delete FOXML
-java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2pdf.xsl -o:"$outfile"-tmp.xml
+# generate the FOXML->PDF, then delete FOXML
 $fop "$outfile"-tmp.xml "$outfile".pdf
 rm "$outfile"-tmp.xml
-
-# generate the HTML
-java -cp $saxon net.sf.saxon.Transform -s:$2 -xsl:../transformations/tagLibrary2html.xsl -o:"$outfile".html
 
 echo "All done!"

--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -23,8 +23,10 @@
 
         <xsl:strip-space elements="*"/>
 
+        <!-- variables passed from the build script to the XSLT -->
+        <xsl:param name="SAA" as="xs:string" required="yes"/>
+
         <xsl:variable name="currentLanguage">en</xsl:variable> <!-- xml:lang from taglibrary -->       
-        <xsl:variable name="SAA">no</xsl:variable><!-- Used for inserting SAA logo or not Values: yes | no -->
         <xsl:variable name="toctype">short</xsl:variable><!-- Used for the look of the toc Values: long | short -->
         <xsl:param name="spaceCharacter"> </xsl:param> <!-- For egxml formatting -->       
         <xsl:variable name="bulletpoint">&#x2022;</xsl:variable>

--- a/transformations/tagLibrary2pdf.xsl
+++ b/transformations/tagLibrary2pdf.xsl
@@ -16,8 +16,10 @@
     xpath-default-namespace="http://www.tei-c.org/ns/1.0" extension-element-prefixes="exslt"
     version="2.0">
 
+    <!-- variables passed from the build script to the XSLT -->
+    <xsl:param name="SAA" as="xs:string" required="yes"/>
+
     <xsl:output indent="yes"/>
-    <xsl:variable name="SAA">yes</xsl:variable>
     <!-- Used for inserting SAA logo or not Values: yes | no -->
     <xsl:variable name="currentLanguage">en</xsl:variable>
     <!-- xml:lang from taglibrary -->


### PR DESCRIPTION
Another build script PR to properly implement passing variables to Saxon for XSLT.  This renders the SAA logo for EAC and EAD tag libraries, but not PREMIS.

This should also serve as a template for swapping various variables out of the XSLT to the build script in the future.