### PR TITLE
eac preparation

### DIFF
--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -43,6 +43,8 @@
                 select="$headingtranslations//*:terms/*:term[@name='summary']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="description"
                 select="$headingtranslations//*:terms/*:term[@name='description']/*:translation[@lang=$currentLanguage]"/>
+        <xsl:variable name="desc"
+                select="$headingtranslations//*:terms/*:term[@name='desc']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="mayoccurwithin"
                 select="$headingtranslations//*:terms/*:term[@name='mayOccurWithin']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="mandatory"
@@ -460,7 +462,6 @@
                         <xsl:apply-templates select="tei:div[@type='summary']"/>
                         <xsl:apply-templates select="tei:div[@type='attributeusage']"/>
                         <xsl:apply-templates select="tei:div[@type='seealso']"/>
-                        <xsl:apply-templates select="tei:div[@type='usage']"/>
                         <xsl:apply-templates select="tei:div[@type='mayContain']"/>
                         <xsl:apply-templates select="tei:div[@type='semanticcomponents']"/>
                         <xsl:apply-templates select="tei:div[@type='mayOccurWithin']"/>
@@ -469,6 +470,8 @@
                         <xsl:apply-templates select="tei:div[@type='rationale']"/>
                         <xsl:apply-templates select="tei:div[@type='datatype']"/>
                         <xsl:apply-templates select="tei:div[@type='description']"/>
+                        <xsl:apply-templates select="tei:div[@type='desc']"/>
+                        <xsl:apply-templates select="tei:div[@type='usage']"/>
                         <xsl:apply-templates select="tei:div[@type='references']"/>
                         <xsl:apply-templates select="tei:div[@type='attributes']"/>
                         <xsl:apply-templates select="tei:div[@type='occurrence']"/>
@@ -487,6 +490,7 @@
                         <xsl:apply-templates select="tei:div[@type='fullName']"/>
                         <xsl:apply-templates select="tei:div[@type='summary']"/>
                         <xsl:apply-templates select="tei:div[@type='description']"/>
+                        <xsl:apply-templates select="tei:div[@type='desc']"/>
                         <xsl:apply-templates select="tei:div[@type='usage']"/>
                         <xsl:apply-templates select="tei:div[@type='mayContain']" mode="dep"/>
                         <xsl:apply-templates select="tei:div[@type='mayOccurWithin']" mode="dep"/>
@@ -506,6 +510,8 @@
                         <xsl:apply-templates select="tei:head/tei:att"/>
                         <xsl:apply-templates select="tei:div[@type='summary']"/>
                         <xsl:apply-templates select="tei:div[@type='description']"/>
+                        <xsl:apply-templates select="tei:div[@type='desc']"/>
+                        <xsl:apply-templates select="tei:div[@type='usage']"/>
                         <xsl:apply-templates select="tei:div[@type='datatype']"/>
                         <xsl:apply-templates select="tei:div[@type='values']"/> 
                         <xsl:apply-templates select="tei:div[@type='examples']"/>
@@ -643,7 +649,7 @@
                 </div>
         </xsl:template>
 
-        <xsl:template match="tei:div[@type=('summary', 'definition', 'entity', 'rationale', 'creationmaintenance', 'usagenotes', 'description')]">
+        <xsl:template match="tei:div[@type=('summary', 'definition', 'entity', 'rationale', 'creationmaintenance', 'usagenotes', 'description', 'desc', 'usage')]">
                 <div class="leftcol">
                         <xsl:variable name="termtitle"><xsl:value-of select="current()/@type"/></xsl:variable>
                         <xsl:value-of select="$headingtranslations/*:terms/*:term[@name=$termtitle]/*:translation[@lang=$currentLanguage]"/>
@@ -719,7 +725,7 @@
         </xsl:template>-->
         
         <!-- When we have description and usage in one header -->
-        <xsl:template match="tei:div[@type='usage'] | tei:div[@type='descriptionAndUsage']">
+        <xsl:template match="tei:div[@type='descriptionAndUsage']">
                 <div class="span">
                         <xsl:apply-templates/>
                 </div>
@@ -787,7 +793,7 @@
                 </xsl:choose>
         </xsl:template>
         
-        
+     
         <xsl:template
                 match="tei:div[@type='attributeusage'][parent::tei:div[@type='elementDocumentation']]/tei:list[@type='simple']">
                              <div class="leftcol">
@@ -799,10 +805,9 @@
                                                 
                                                 <xsl:apply-templates/>
                                                 <br/>
-                                                <br/>
                                         </xsl:for-each>
                                 </div>
-        </xsl:template>
+        </xsl:template> 
         <xsl:template
                 match="tei:div[@type='seealso'][parent::tei:div[@type='elementDocumentation']]/tei:list[@type='simple']">
                 <div class="leftcol">
@@ -813,7 +818,6 @@
                         <xsl:for-each select="tei:item">
                                 
                                 <xsl:apply-templates/>
-                                <br/>
                                 <br/>
                         </xsl:for-each>
                 </div>
@@ -1143,5 +1147,18 @@
                         <xsl:text> </xsl:text>
                 </xsl:if>
         </xsl:template>
-        
+
+    <!-- formatting tags -->
+    <xsl:template match="tei:bold">
+        <xsl:text> </xsl:text>
+        <strong>
+            <xsl:apply-templates/>
+        </strong>
+    </xsl:template>
+    <xsl:template match="tei:italic">
+        <xsl:text> </xsl:text>
+        <em>
+            <xsl:apply-templates/>
+        </em>
+    </xsl:template>        
 </xsl:stylesheet>

--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -674,6 +674,25 @@
                                         <xsl:when test="contains(., '&quot;') or contains(., '[')">
                                                 <xsl:value-of select="normalize-space(.)"/>
                                         </xsl:when>
+                                        <xsl:when test="contains(., ' or ')">
+                                            <xsl:for-each select="tokenize(., ' or ')">
+                                                <xsl:choose>
+                                                    <xsl:when test="contains(., '(')">
+                                                        <a href="#{translate(concat('elem-', normalize-space(substring-before(., '('))), ':','')}">
+                                                                <xsl:value-of select="normalize-space(.)"/>
+                                                        </a>
+                                                    </xsl:when>
+                                                    <xsl:otherwise>
+                                                            <a href="#{translate(concat('elem-', normalize-space(.)), ':','')}">
+                                                                    <xsl:value-of select="normalize-space(.)"/>
+                                                            </a>
+                                                    </xsl:otherwise>
+                                                </xsl:choose>
+                                                <xsl:if test="position() ne last()">
+                                                    <xsl:text> or </xsl:text>
+                                                </xsl:if>
+                                            </xsl:for-each>
+                                        </xsl:when>
                                         <xsl:when test="contains(., '(')">
                                                 <a href="#{translate(concat('elem-', normalize-space(substring-before(., '('))), ':','')}">
                                                         <xsl:value-of select="normalize-space(.)"/>

--- a/transformations/tagLibrary2pdf.xsl
+++ b/transformations/tagLibrary2pdf.xsl
@@ -72,6 +72,8 @@
         select="$headingtranslations//*:terms/*:term[@name = 'examples']/*:translation[@lang = $currentLanguage]"/>
     <xsl:variable name="example"
         select="$headingtranslations//*:terms/*:term[@name = 'example']/*:translation[@lang = $currentLanguage]"/>
+    <xsl:variable name="desc"
+        select="$headingtranslations//*:terms/*:term[@name = 'desc']/*:translation[@lang = $currentLanguage]"/>
     <xsl:variable name="usage"
         select="$headingtranslations//*:terms/*:term[@name = 'usage']/*:translation[@lang = $currentLanguage]"/>
     <xsl:variable name="and"
@@ -696,6 +698,7 @@
             <xsl:apply-templates select="tei:div[@type = 'datatype']"/>
             <xsl:apply-templates select="tei:div[@type = 'attributes']"/>
             <xsl:apply-templates select="tei:div[@type = 'description']"/>
+            <xsl:apply-templates select="tei:div[@type = 'desc']"/>
             <xsl:apply-templates select="tei:div[@type = 'usage']"/>
             <xsl:apply-templates select="tei:div[@type = 'occurrence']"/>
             <xsl:apply-templates select="tei:div[@type = 'availability']"/>
@@ -748,6 +751,8 @@
             </fo:block>
             <xsl:apply-templates select="tei:div[@type = 'summary']"/>
             <xsl:apply-templates select="tei:div[@type = 'description']"/>
+            <xsl:apply-templates select="tei:div[@type = 'desc']"/>
+            <xsl:apply-templates select="tei:div[@type = 'usage']"/>
             <xsl:apply-templates select="tei:div[@type = 'datatype']"/>
             <xsl:apply-templates select="tei:div[@type = 'values']"/>
             <xsl:apply-templates select="tei:div[@type = 'examples']"/>
@@ -812,6 +817,7 @@
         </fo:block>
         <xsl:apply-templates select="tei:div[@type = 'summary']"/>
         <xsl:apply-templates select="tei:div[@type = 'description']"/>
+        <xsl:apply-templates select="tei:div[@type = 'desc']"/>
         <xsl:apply-templates select="tei:div[@type = 'usage']"/>
         <xsl:apply-templates select="tei:div[@type = 'mayContain']" mode="deprecated"/>
         <xsl:apply-templates select="tei:div[@type = 'mayOccurWithin']" mode="deprecated"/>
@@ -899,7 +905,7 @@
 
     <!-- Non-tokenized note divs -->
     <xsl:template
-        match="tei:div[@type = ('summary', 'definition', 'rationale', 'creationmaintenance', 'usagenotes', 'attributeusage', 'seealso', 'datatype', 'values', 'availability', 'attributeusage', 'reference', 'references')]">
+        match="tei:div[@type = ('summary', 'definition', 'rationale', 'creationmaintenance', 'usagenotes', 'attributeusage', 'seealso', 'datatype', 'values', 'availability', 'attributeusage', 'reference', 'references', 'desc', 'usage', 'description')]">
         <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
             <fo:list-item>
                 <fo:list-item-label end-indent="label-end()">
@@ -1000,45 +1006,6 @@
         </fo:list-block>
     </xsl:template>
 
-    <!-- To be used when description is it own header -->
-    <!--<xsl:template match="tei:div[@type='description']">
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block>
-                        <xsl:value-of select="$description"/>
-                        <xsl:text>: </xsl:text>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>-->
-
-    <xsl:template
-        match="tei:div[@type = 'description'][parent::tei:div[@type = 'elementDocumentation']]">
-        <!-- Combination of description and usage -->
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block font-weight="bold">
-                        <xsl:value-of select="$description"/>
-                        <xsl:text>: </xsl:text>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>
-
     <xsl:template match="tei:div[@type = 'entity'][parent::tei:div[@type = 'elementDocumentation']]">
         <!-- Entity information PREMIS DD -->
         <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
@@ -1058,98 +1025,6 @@
         </fo:list-block>
     </xsl:template>
 
-    <xsl:template
-        match="tei:div[@type = 'description'][parent::tei:div[@type = 'deprecatedElementDocumentation']]">
-        <!-- Combination of description and usage -->
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block font-weight="bold">
-                        <xsl:value-of select="$description"/>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>
-
-    <xsl:template
-        match="tei:div[@type = 'description'][parent::tei:div[@type = 'deprecatedAttributeDocumentation']]">
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block font-weight="bold">
-                        <xsl:value-of select="$description"/>
-                        <xsl:text>: </xsl:text>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>
-
-    <xsl:template
-        match="tei:div[@type = 'description'][parent::tei:div[@type = 'attributeDocumentation']]">
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block font-weight="bold">
-                        <xsl:value-of select="$description"/>
-                        <xsl:text>: </xsl:text>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>
-
-    <!-- <xsl:template match="tei:div[@type='usage']">
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block>
-                        <xsl:value-of select="$usage"/>
-                        <xsl:text>: </xsl:text>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>-->
-
-    <xsl:template match="tei:div[@type = 'usage']">
-        <!-- Combination of description and usage -->
-        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
-            <fo:list-item>
-                <fo:list-item-label end-indent="label-end()">
-                    <fo:block font-weight="bold">
-                        <xsl:text> </xsl:text>
-                    </fo:block>
-                </fo:list-item-label>
-                <fo:list-item-body start-indent="body-start()">
-                    <fo:block>
-                        <xsl:apply-templates/>
-                    </fo:block>
-                </fo:list-item-body>
-            </fo:list-item>
-        </fo:list-block>
-    </xsl:template>
 
     <!-- commenting these templates out, but keeping them in case they're needed again later
     these templates should be superseded by the occurrence template...
@@ -1878,4 +1753,17 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
+
+    <!-- formatting tags -->
+    <xsl:template match="bold">
+        <fo:inline font-weight="bold">
+            <xsl:apply-templates/>
+        </fo:inline>
+    </xsl:template>
+    <xsl:template match="italic">
+        <fo:inline font-style="italic">
+            <xsl:apply-templates/>
+        </fo:inline>
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/transformations/tagLibrary2pdf.xsl
+++ b/transformations/tagLibrary2pdf.xsl
@@ -944,7 +944,7 @@
                 <fo:list-item-body start-indent="body-start()">
                     <fo:block>
                         <xsl:call-template name="tokenize">
-                            <xsl:with-param name="text" select="tei:p"/>
+<!--                            <xsl:with-param name="text" select="tei:p"/> -->
                         </xsl:call-template>
                     </fo:block>
                 </fo:list-item-body>
@@ -1632,71 +1632,49 @@
 
 
     <xsl:template name="tokenize">
-        <xsl:param name="text" select="."/>
-        <xsl:param name="separator" select="','"/>
-        <xsl:choose>
-            <xsl:when test="contains($text, 'base64Binary')">
-                <xsl:value-of select="normalize-space($text)"/>
-            </xsl:when>
-            <xsl:when test="contains($text, '&#34;')">
-                <xsl:value-of select="normalize-space($text)"/>
-            </xsl:when>
-            <xsl:when test="contains($text, 'NMTOKEN')">
-                <xsl:value-of select="normalize-space($text)"/>
-            </xsl:when>
-            <xsl:when test="contains($text, 'ROOT')">
-                <xsl:value-of select="normalize-space($text)"/>
-            </xsl:when>
-            <xsl:when test="not(contains($text, $separator))">
-                <xsl:choose>
-                    <xsl:when test="(contains($text, '(revised')) and (not(contains($text, '[')))">
+        <xsl:for-each select="tokenize(., ',')">
+            <xsl:choose>
+                <xsl:when test="contains(., 'base64Binary')">
+                    <xsl:value-of select="normalize-space(.)" />
+                </xsl:when>
+                <xsl:when test="contains(., '&#34;')">
+                    <xsl:value-of select="normalize-space(.)" />
+                </xsl:when>
+                <xsl:when test="contains(., 'NMTOKEN')">
+                    <xsl:value-of select="normalize-space(.)" />
+                </xsl:when>
+                <xsl:when test="contains(., 'ROOT')">
+                    <xsl:value-of select="normalize-space(.)" />
+                </xsl:when>
+                <xsl:when test="contains(., ' or ')">
+                    <xsl:for-each select="tokenize(., ' or ')">
+                        <xsl:call-template name="tokenize"/>
+                        <xsl:if test="position() ne last()">
+                            <xsl:text> or </xsl:text>
+                        </xsl:if>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:when test="contains(., '[')">
+                    <xsl:value-of select="normalize-space(.)" />
+                </xsl:when>
+                <xsl:when test="contains(., '(')">
                         <!-- remove "(revised in x.y.z)" text from title -->
                         <fo:basic-link
-                            internal-destination="{concat('elem-', normalize-space(substring-before(concat($text, '('), '(')))}">
-                            <xsl:value-of select="normalize-space($text)"/>
+                            internal-destination="{concat('elem-', normalize-space(substring-before(concat(., '('), '(')))}">
+                            <xsl:value-of select="normalize-space(.)"/>
                         </fo:basic-link>
-                    </xsl:when>
-                    <xsl:when test="not(contains($text, '['))">
-                        <!-- elements have an id with elem- first -->
-                        <fo:basic-link
-                            internal-destination="{concat('elem-', translate(normalize-space($text), ':',''))}">
-                            <xsl:value-of select="normalize-space($text)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <fo:basic-link
+                            internal-destination="{concat('elem-', translate(normalize-space(.), ':',''))}">
+                            <xsl:value-of select="normalize-space(.)"/>
                         </fo:basic-link>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="normalize-space($text)"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:choose>
-                    <xsl:when test="(contains($text, '(revised')) and (not(contains($text, '[')))">
-                        <!-- remove "(revised in x.y.z)" text from title -->
-                        <fo:basic-link
-                            internal-destination="{concat('elem-', normalize-space(substring-before(concat(substring-before($text, $separator), '('), '(')))}">
-                            <xsl:value-of
-                                select="normalize-space(substring-before($text, $separator))"/>
-                        </fo:basic-link>
-                    </xsl:when>
-                    <xsl:when test="not(contains($text, '['))">
-                        <!-- elements have an id with elem- first -->
-                        <fo:basic-link
-                            internal-destination="{concat('elem-', normalize-space(substring-before($text, $separator)))}">
-                            <xsl:value-of
-                                select="normalize-space(substring-before($text, $separator))"/>
-                        </fo:basic-link>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="normalize-space(substring-before($text, $separator))"
-                        />
-                    </xsl:otherwise>
-                </xsl:choose>
-                <xsl:text>, </xsl:text>
-                <xsl:call-template name="tokenize">
-                    <xsl:with-param name="text" select="substring-after($text, $separator)"/>
-                </xsl:call-template>
-            </xsl:otherwise>
-        </xsl:choose>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="position() ne last()">
+                            <xsl:text>, </xsl:text>
+                        </xsl:if>
+        </xsl:for-each>
     </xsl:template>
 
     <xsl:template name="tokenizeattributes">


### PR DESCRIPTION
Resolves the following issues:

#57 - support for technical description of Availability and May Contain, which works with links (thanks @ailie-s !)
#58 - support for `Description` and `Usage` sections in the tag library (in addition to `Description and Usage`)
#65 - now includes a `<bold>` and `<italic>` tag in the TEI for bolding/italicizing text
