### PR TITLE
HTML toc now reads vertically

### DIFF
--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -232,7 +232,7 @@
                                         </div>
                                         <div class="toc2">
                                             <table>
-                                                    <xsl:for-each-group select="tei:div[@type='elementDocumentation']" group-ending-with="tei:div[@type='elementDocumentation'][position() mod 7 = 0]">
+                                                    <xsl:for-each-group select="tei:div[@type='elementDocumentation']" group-by="position() mod 20">
                                                         <tr>
                                                             <xsl:for-each select="current-group()">
                                                                 <td>
@@ -258,7 +258,7 @@
                                         </div>
                                         <div class="toc2">
                                             <table>
-                                                    <xsl:for-each-group select="tei:div[@type='attributeDocumentation']" group-ending-with="tei:div[@type='attributeDocumentation'][position() mod 7 = 0]">
+                                                    <xsl:for-each-group select="tei:div[@type='attributeDocumentation']" group-by="position() mod 15">
                                                         <tr>
                                                             <xsl:for-each select="current-group()">
                                                                 <td>
@@ -283,22 +283,17 @@
                                                 </a>
                                         </div>
                                         <div class="toc2">
+                                                <table>
                                                 <xsl:for-each select="tei:div/tei:head">
-                                                  <span>
-                                                          <a href="#{translate(translate(concat('appendix-' , .), ':',''), ' ','')}">
-                                                                  <xsl:value-of select="."/>
-                                                          </a>
-                                                  <xsl:text> &#xA0; </xsl:text>
-                                                  </span>
-                                                  <xsl:for-each select="parent::tei:div">
-                                                  <xsl:variable name="count">
-                                                  <xsl:number/>
-                                                  </xsl:variable>
-                                                  <xsl:if test="($count mod 6) = 0">
-                                                  <br/>
-                                                  </xsl:if>
-                                                  </xsl:for-each>
+                                                        <tr>
+                                                                <td>
+                                                                        <a href="#{translate(translate(concat('appendix-' , .), ':',''), ' ','')}">
+                                                                                <xsl:value-of select="."/>
+                                                                        </a>
+                                                                </td>
+                                                        </tr>
                                                 </xsl:for-each>
+                                                </table>
                                         </div>
                                 </xsl:when>
                                 <xsl:otherwise>


### PR DESCRIPTION
Previously, the table of contents in HTML read horizontally, which was very difficult to scan.  This changes it to read vertically, which aligns with the PDF and is generally more pleasant to read.

Note that this breaks links to appendices (oops) - fixing this is a TODO