### PR TITLE
#113 - fixing parallel values in EAD3

### DIFF
--- a/tei/EAD3-TL-eng.xml
+++ b/tei/EAD3-TL-eng.xml
@@ -2181,7 +2181,7 @@
                         <gi>physdescset</gi>.</p>
                </div>
                <div type="values">
-                  <p>part, whole</p>
+                  <p>false, true</p>
                </div>
                <div type="examples">
                   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="eng" valid="true">


### PR DESCRIPTION
Changing values for `@parallel` in EAD3 to `false, true`, which are its correct values.