### PR TITLE
Narrative event

### DIFF
--- a/tei/shared/en/elem-agent.xml
+++ b/tei/shared/en/elem-agent.xml
@@ -85,11 +85,10 @@
     </div>
     <div type="availability">
       <p type="eac">Within <gi>maintenanceEvent</gi>: required, not repeatable</p>
-      <p type="eac">Within <gi>narrativeEvent</gi>: optional, not repeatable</p>
+      <p type="eac">Within <gi>narrativeEvent</gi>: optional, repeatable</p>
       <p type="ead">Within <gi>agents</gi>: required, repeatable</p>
-      <p type="ead">Within <gi>findAidDesc</gi>: optional, repeatable</p>
+      <p type="ead">Within <gi>findAidDesc</gi> and <gi>narrativeEvent</gi>: optional, repeatable</p>
       <p type="ead">Within <gi>maintenanceEvent</gi>: required, not repeatable</p>
-      <p type="ead">Within <gi>narrativeEvent</gi>: optional, not repeatable</p>
       <p type="eaf">Required, not repeatable</p>
     </div>
     <div type="examples">

--- a/tei/shared/en/elem-date.xml
+++ b/tei/shared/en/elem-date.xml
@@ -83,11 +83,11 @@
 	<div type="availability">
 		<p type="eac">Within <gi>agent</gi>, <gi>demographicDescription</gi>, <gi>functionPerformed</gi>,  <gi>legalStatus</gi>, <gi>localDescription</gi>, <gi>mandate</gi>, <gi>occupation</gi>, <gi>otherEntityType</gi>, <gi>place</gi>, <gi>relation</gi>: one of <gi>date</gi>, <gi>dateRange</gi>, or <gi>dateSet</gi> optional, not repeatable</p>
 		<p type="eac">Within <gi>existDates</gi> and <gi>useDates</gi>: one of <gi>date</gi>, <gi>dateRange</gi>, or <gi>dateSet</gi> required, not repeatable</p>
-		<p type="eac">Within <gi>narrativeEvent</gi>: required, not repeatable</p>
+		<p type="eac">Within <gi>narrativeEvent</gi>: required, repeatable</p>
 		<p type="ead">Within <gi>agent</gi>, <gi>formAvailable</gi>, <gi>function</gi>, <gi>legalStatus</gi>, <gi>place</gi>, <gi>relation</gi>, <gi>subject</gi>, <gi>unitDate</gi>: one of <gi>date</gi>, <gi>dateRange</gi>, or <gi>dateSet</gi> optional, not repeatable</p>
 		<p type="ead">Within <gi>findAidDesc</gi>: at least one of <gi>agent</gi>, <gi>citedRange</gi>, 
  <gi>date</gi>, <gi>formattingExtension</gi>, <gi>place</gi> or <gi>title</gi> required, repeatable</p>
-		<p type="ead">Within <gi>narrativeEvent</gi>: required, not repeatable</p>
+		<p type="ead">Within <gi>narrativeEvent</gi>: required, repeatable</p>
 		<p type="eaf">Within <gi>agent</gi>, <gi>legislation</gi>, <gi>relation</gi>: one of <gi>date</gi>, <gi>dateRange</gi>, or <gi>dateSet</gi> optional, not repeatable</p>
 		<p type="eaf">Within <gi>useDates</gi>: one of <gi>date</gi>, <gi>dateRange</gi>, or <gi>dateSet</gi> required, not repeatable</p>
 		<p type="eaf">Within <gi>functionDates</gi>: one of <gi>date</gi> or <gi>dateRange</gi> required, not repeatable</p>

--- a/tei/shared/en/elem-narrativeEvent.xml
+++ b/tei/shared/en/elem-narrativeEvent.xml
@@ -14,13 +14,13 @@
 		<p>
 			<list type="gloss">
 				<label>agent</label>
-				<item>0..1</item>
+				<item>0..n</item>
 				<label>date</label>
-				<item>1..1</item>
+				<item>1..n</item>
 				<label>eventDescription</label>
 				<item>0..n</item>
 				<label>placeName</label>
-				<item>0..1</item>
+				<item>0..n</item>
 			</list>
 		</p>
 	</div>


### PR DESCRIPTION
Following the decision at the TS-EAS annual meeting on 11 August (see https://github.com/SAA-SDT/eas-schemas/issues/238), the TEI XML files for `<narrativeEvent>` and its sub-elements `<date>` and `<agent>` have been updated to reflect the repeatability of the sub-elements (see also https://github.com/SAA-SDT/EAS-TagLibraries/issues/203).