### PR TITLE
Update elem-objectXMLWrap.xml

### DIFF
--- a/tei/ead4/en/elem-physicalDescription.xml
+++ b/tei/ead4/en/elem-physicalDescription.xml
@@ -49,7 +49,7 @@
 		</p>
 	</div>
 	<div type="description">
-		<p><gi>physicalDescription</gi> creates structured statements describing the physical or logical extent or the medium of the instantiation described in <gi>formAvailable</gi>. While optional individually, one of the child elements <gi>dimensions</gi>, <gi>extent</gi> or <gi>physicalFacet</gi> has to be included when using <gi>physicalDescription</gi>. Next to the descriptive, human-readabile information, the structured design of <gi>physicalDescription</gi> allows for quantifying the extent of the whole or a part of the instantiation described in a form that will also be machine-processable and that will facilitate reporting, statistics, sorting, and importing and exporting data in a collection management system.</p>
+		<p><gi>physicalDescription</gi> creates structured statements describing the physical or logical extent or the medium of the instantiation described in <gi>formAvailable</gi>. While optional individually, one of the child elements <gi>dimensions</gi>, <gi>extent</gi> or <gi>physicalFacet</gi> has to be included when using <gi>physicalDescription</gi>. Next to the descriptive, human-readable information, the structured design of <gi>physicalDescription</gi> allows for quantifying the extent of the whole or a part of the instantiation described in a form that will also be machine-processable and that will facilitate reporting, statistics, sorting, and importing and exporting data in a collection management system.</p>
                   <p>The prescribed order of all child elements (both required and optional) is:</p>
                   <list type="simple">
                      <item>
@@ -68,7 +68,7 @@
 		  <p>Use <gi>objectXMLWrap</gi> in <gi>descriptiveNote</gi> to include, where necessary, more detailed information encoded in another standard such as MIX, AudioMD, national standards focussed specifically on digital instantiations, etc.</p>
                </div>
                <div type="seealso">
-		<p>When statements of physical or logical extent relate to the record resource in general rather than being specific to an individual instantiation, use <gi>extent</gi> within <gi>identificationData</gi>. E.g. a photographic collection might consist of 1,200 photographs, a statement captured in <gi>extent</gi> within <gi>identificationData</gi>. Within <gi>physicalDescription</gi> in repeated <gi>formAvailable</gi> elements, this might then be specified as "1,2000 prints" for one analog instantation, "1,200 negatives" for a second analog instantiation, and "1,200 image files (tiff)" for a digital instantiation.</p>
+		<p>When statements of extent relate to the record resource in general rather than being specific to an individual instantiation, use <gi>extent</gi> within <gi>identificationData</gi>. E.g. a photographic collection might consist of 1,200 photographs, a statement captured in <gi>extent</gi> within <gi>identificationData</gi>. Within <gi>physicalDescription</gi> in repeated <gi>formAvailable</gi> elements, this might then be specified as "1,2000 prints" for one analog instantation, "1,200 negatives" for a second analog instantiation, and "1,200 image files (tiff)" for a digital instantiation.</p>
 	</div>
 	<div type="availability">
 		<p>Optional, repeatable</p>

--- a/tei/ead4/en/elem-physicalDescription.xml
+++ b/tei/ead4/en/elem-physicalDescription.xml
@@ -74,7 +74,8 @@
 		<p>Optional, repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng"><![CDATA[<formsAvailable>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+			<![CDATA[<formsAvailable>
 			<formAvailable formAvailableType="digitalOriginal" coverage="whole">
 			<label>Photographs</label>
 			<physicalDescription>
@@ -113,8 +114,9 @@
 		</dimensions>
 		</physicalDescription>
 		</formAvailable>
-		</formsAvailable>]]></egXML>
-		<egXML xml:lang="eng">
+		</formsAvailable>]]>
+		</egXML>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
 			<![CDATA[<formAvailable>
 			<label>Born digital archives (audiovisual)</label>
 			<role>copie</role>
@@ -153,6 +155,7 @@
 			<unitOfMeasurement>bytes</unitOfMeasurement>
 		</extent>
 		</physicalDescription>
-		</formAvailable>]]></egXML>
+		</formAvailable>]]>
+		</egXML>
 	</div>
 </div>

--- a/tei/ead4/en/elem-physicalFacet.xml
+++ b/tei/ead4/en/elem-physicalFacet.xml
@@ -65,7 +65,7 @@
 		<p>Optional, not repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng"><![CDATA[<formsAvailable>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<formsAvailable>
 			<formAvailable formAvailableType="digitalOriginal" coverage="whole">
 			<label>Photographs</label>
 			<physicalDescription>
@@ -78,7 +78,7 @@
 		</formAvailable>
 		</formsAvailable>]]>
 		</egXML>
-		<egXML xml:lang="eng"><![CDATA[<physicalDescription>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<physicalDescription>
 			<extent coverage="part" extentType="materialType">
 			<quantity>5</quantity>
 			<unitOfMeasurement>daguerreotypes</unitOfMeasurement>
@@ -90,7 +90,7 @@
 			<physicalFacet valueURI="http://vocab.getty.edu/page/aat/300457737" vocabularySource="AAT">hand-tinted</physicalFacet>
 		</physicalDescription>]]>
 		</egXML>
-		<egXML xml:lang="eng"><![CDATA[<physicalDescription>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<physicalDescription>
 			<extent coverage="part" extentType="materialType">
 			<quantity>10</quantity>
 			<unitOfMeasurement>videocassettes</unitOfMeasurement>

--- a/tei/ead4/en/elem-physicalFacet.xml
+++ b/tei/ead4/en/elem-physicalFacet.xml
@@ -7,7 +7,7 @@
 		<p>Physical Facet</p>
 	</div>
 	<div type="summary">
-		<p>A child element of <gi>physicalDescription</gi> that provides more detailed information about the physical nature of or techniques and methods of creation of a specific instantiation of the material described in terms that are often taken from a controlled vocabulary list.</p>
+		<p>A child element of <gi>physicalDescription</gi> that provides more detailed information about the physical nature or techniques and methods of creation of a specific instantiation of the material described, in terms that are often taken from a controlled vocabulary list.</p>
 	</div>
 	<div type="mayContain">
 		<p><list type="gloss">
@@ -73,7 +73,7 @@
 			<quantity>7,500</quantity>
 			<unitOfMeasurement>electronic files</unitOfMeasurement>
 		</extent>
-			<physicalFacet valueURI="http://vocab.getty.edu/page/aat/300391245" vocabularySource="AAT">false-color infrared photography</physicalFacet>
+			<physicalFacet valueURI="http://vocab.getty.edu/aat/300391245" vocabularySource="AAT">false-color infrared photography</physicalFacet>
 		</physicalDescription>
 		</formAvailable>
 		</formsAvailable>]]>
@@ -81,7 +81,7 @@
 		<egXML xml:lang="eng"><![CDATA[<physicalDescription>
 			<extent coverage="part" extentType="materialType">
 			<quantity>5</quantity>
-			<unitOfMeasurement>dageurreotypes</unitOfMeasurement>
+			<unitOfMeasurement>daguerreotypes</unitOfMeasurement>
 		</extent>
 			<dimensions>
 			<quantity>6.5 x 8.5</quantity>

--- a/tei/ead4/en/elem-physicalOrTechnicalRequirements.xml
+++ b/tei/ead4/en/elem-physicalOrTechnicalRequirements.xml
@@ -7,7 +7,7 @@
 		<p>Physical Characteristics or Technical Requirements</p>
 	</div>
 	<div type="summary">
-		<p>For describing the physical condition of the materials and/or technical requirements that affect their use.</p>
+		<p>An optional child element of <gi>formAvailable</gi> for describing the physical condition of the materials and/or technical requirements that affect their use.</p>
 	</div>
 	<div type="mayContain">
 		<p><list type="gloss">
@@ -49,7 +49,7 @@
     		</p>
 	</div>
 	<div type="description">
-		<p><gi>physicalOrTechnicalRequirements</gi> is used to capture any physical or technical characteristics that affect the storage or use of the specific form of the archival record being described described. This may hence be different for an analog or digital form. <gi>physicalOrTechnicalRequirements</gi> may include details of the specific form's physical composition, preservation requirements, or particular hardware or software needed to access the materials.</p>
+		<p><gi>physicalOrTechnicalRequirements</gi> is used to capture any physical or technical characteristics that affect the storage or use of the specific form of the archival record being described. This may hence be different for an analog or digital form. <gi>physicalOrTechnicalRequirements</gi> may include details of the specific form's physical composition, preservation requirements, or particular hardware or software needed to access the materials.</p>
 		<p>Use the element <gi>abstract</gi> to provide a brief summary of the information encoded in <gi>physicalOrTechnicalRequirements</gi>. Use the repeatable <gi>p</gi> element to structure longer texts in several paragraphs. If required and suitable, use <gi>formattingExtension</gi> to make use of more detailed formatting options such as lists, tables, or section headers in XHTML.</p>
 		<p>The prescribed order of all child elements (both required and optional) is:</p>
 		<list type="simple">
@@ -68,7 +68,7 @@
 			<formAvailable>
 			[...]
 			<physicalOrTechnicalRequirements>
-			<p>Due to already existing oxidative corrosion, the original daguerrotypes can only be viewed upon request and at the archive, where suitable conditions (dimmed lighting, low humidity) can be guaranteed.</p>
+			<p>Due to already existing oxidative corrosion, the original daguerreotypes can only be viewed upon request and at the archive, where suitable conditions (dimmed lighting, low humidity) can be guaranteed.</p>
 		</physicalOrTechnicalRequirements>
 		</formAvailable>
 		</formsAvailable>

--- a/tei/ead4/en/elem-quantity.xml
+++ b/tei/ead4/en/elem-quantity.xml
@@ -50,7 +50,8 @@
 		<p>Optional, not repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng"><![CDATA[<c>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+			<![CDATA[<c>
 			<identificationData>
 			<unitTitle>Seizure Records</unitTitle>
 			<unitDate>
@@ -68,8 +69,10 @@
 			<unitOfMeasurement>folder</unitOfMeasurement>
 		</extent>
 		</identificationData>
-		</c>]]></egXML>
-		<egXML xml:lang="eng"><![CDATA[<formsAvailable>
+		</c>]]>
+		</egXML>
+		<egXML xml:lang="eng"xmlns="http://www.tei-c.org/ns/Examples">
+			<![CDATA[<formsAvailable>
 			<formAvailable formAvailableType="digitalOriginal" coverage="whole">
 			<label>Photographs</label>
 			<physicalDescription>
@@ -92,6 +95,7 @@
 		</dimensions>
 		</physicalDescription>
 		</formAvailable>
-		</formsAvailable>]]></egXML>
+		</formsAvailable>]]>
+		</egXML>
 	</div>
 </div>

--- a/tei/ead4/en/elem-recordTypeSpecificStatement.xml
+++ b/tei/ead4/en/elem-recordTypeSpecificStatement.xml
@@ -66,12 +66,12 @@
 		<p>Optional, Repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng">
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
 			<![CDATA[<recordTypeSpecificStatement>
 			<p>Autograph conductor's full score (pencil), with mimeographed conductor's short score of certain sections interleaved. Selections, including deletions.</p>
 		</recordTypeSpecificStatement>]]>
 		</egXML>
-		<egXML xml:lang="eng">
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
 			<![CDATA[<recordTypeSpecificStatement>
 			<objectXMLWrap>
 			<mods:cartographics xmlns:mods="https://www.loc.gov/standards/mods/mods-3-8.xsd">

--- a/tei/ead4/en/elem-relatedMaterial.xml
+++ b/tei/ead4/en/elem-relatedMaterial.xml
@@ -95,7 +95,7 @@
 			<![CDATA[<relatedMaterial>
 			<!-- Note: the following encoding is based on using the NVDL schema for EAD 4.0, which has the XHTML schema integrated already; the example validates in Oxygen XML Editor 20.1. -->
 			<formattingExtension>
-			<xhtml:div>
+			<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">
 			<xhtml:p>The following sources provide additional information on Gordon Gray's personal and professional life and on the development of the Consolidated University during his tenure as president.</xhtml:p>
 			<xhtml:h4>Southern Historical Collection</xhtml:h4>
 			<xhtml:ul>

--- a/tei/ead4/en/elem-separatedMaterial.xml
+++ b/tei/ead4/en/elem-separatedMaterial.xml
@@ -57,8 +57,8 @@
 		</p>
 	</div>
 	<div type="description">
-		<p>                     <gi>separatedMaterial</gi> identifies materials that are associated by provenance to the described materials that have been physically separated or removed. Examples include the separation of special formats; the destruction of duplicate or nonessential material; and the deliberate or unintentional dispersal of a creator’s records among different repositories.</p>
-		 <p>These separated materials can either be described using narrative text in the elements <gi>abstract</gi>, <gi>p</gi>, and <gi>formattingExtension</gi> or they can be named within and, if applicable, linked to via <gi>relations</gi>. Using <gi>relations</gi> is especially useful when referring to several separated materials at once and will also allow for a more detailed description of the relationship itself by including type and role information or a temporal or geographic dimension of the relationship.</p>
+		<p><gi>separatedMaterial</gi> identifies materials that are associated by provenance to the described materials, and that have been physically separated or removed from them. Examples include the separation of special formats; the destruction of duplicate or nonessential material; and the deliberate or unintentional dispersal of a creator’s records among different repositories.</p>
+		 <p>These separated materials can either be described using narrative text in the elements <gi>abstract</gi>, <gi>p</gi>, and <gi>formattingExtension</gi> or they can be named within and, if applicable, linked to via <gi>relations</gi>. Using <gi>relations</gi> is especially useful when referring to several separated materials at once, and will also allow for a more detailed description of the relationship itself by including type and role information or a temporal or geographic dimension of the relationship.</p>
 		<p>If described in narrative text, the element <gi>reference</gi> within <gi>p</gi> may be used to refer to such separated materials.</p>
 		<p>The prescribed order of all child elements (both required and optional) is:</p>
 		<list type="simple">

--- a/tei/ead4/en/elem-title.xml
+++ b/tei/ead4/en/elem-title.xml
@@ -57,7 +57,7 @@
 		<p>Use the sub-element <gi>part</gi> to break a title down into aspects such as an edition statement (e.g. "2nd edition"). </p>
 		<p>Use repeated <gi>title</gi> elements distinguished by their <att>localType</att>-s when describing e.g. a .pdf or a .docx instantiation of a finding aid to give the publication title for display on the one hand and the file title of the .pdf or the .docx file on the other hand. </p>
 	</div>
-	<div type="attributeusage"><p>Use <att>@localType</att> to differentiate between the general title and a subtitle or the title of an overarching series. </p></div>	
+	<div type="attributeusage"><p>Use <att>localType</att> to differentiate between the general title and a subtitle or the title of an overarching series. </p></div>	
 	<div type="seealso"><p>Do not confuse with <gi>unitTitle</gi>, which is used to encode the name of the described materials, such as the title of a collection or the title or an individual item. </p></div>
 	<div type="availability">
 		<p>Optional, repeatable</p>

--- a/tei/ead4/en/elem-unitOfMeasurement.xml
+++ b/tei/ead4/en/elem-unitOfMeasurement.xml
@@ -55,7 +55,7 @@
 		<p>Optional, not repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng"><![CDATA[<c>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<c>
 			<identificationData>
 			<unitTitle>Seizure Records</unitTitle>
 			<unitDate>
@@ -74,7 +74,7 @@
 		</extent>
 		</identificationData>
 		</c>]]></egXML>
-		<egXML xml:lang="eng"><![CDATA[<formsAvailable>
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<formsAvailable>
 			<formAvailable formAvailableType="digitalOriginal" coverage="whole">
 			<label>Photographs</label>
 			<physicalDescription>

--- a/tei/shared/en/attr-maintenanceEventReference.xml
+++ b/tei/shared/en/attr-maintenanceEventReference.xml
@@ -18,7 +18,7 @@
                   <p>IDREFS</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<maintenanceHistory>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<maintenanceHistory>
                     <maintenanceEvent maintenanceEventType="updated" id="me2">
                     <agent agentType="person">
                     <label>K. Bredenberg</label>

--- a/tei/shared/en/attr-maintenanceEventType.xml
+++ b/tei/shared/en/attr-maintenanceEventType.xml
@@ -17,7 +17,8 @@
                   <p>token</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<maintenanceHistory>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<maintenanceHistory>
                     <maintenanceEvent maintenanceEventType="derived">
                     <agent agentType="machine">
                     <label>export.xsl/Saxon B9</label>
@@ -37,6 +38,7 @@
                   </agent>
                     <eventDateTime>December 2024</eventDateTime>
                   </maintenanceEvent>
-                  </maintenanceHistory>]]></egXML>
+                  </maintenanceHistory>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/attr-maintenanceStatus.xml
+++ b/tei/shared/en/attr-maintenanceStatus.xml
@@ -17,7 +17,7 @@
                <div type="datatype">
 		              <p>token</p>
 	             </div>
-               <div type="examples">
+               <div type="examples" xmlns="http://www.tei-c.org/ns/Examples">
                   <egXML xml:lang="eng"><![CDATA[<control countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" languageEncoding="iso639-2" maintenanceStatus="new" maintenanceStatusEncoding="EASList" publicationStatus="published" publicationStatusEncoding="EASList" repositoryEncoding="iso15511" scriptEncoding="iso15924">
 			  [...]
 		  </control>]]></egXML>

--- a/tei/shared/en/attr-publicationStatus.xml
+++ b/tei/shared/en/attr-publicationStatus.xml
@@ -17,8 +17,10 @@
                   <p>token</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<control countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" languageEncoding="iso639-3" maintenanceStatusEncoding="EASList" maintenanceStatus="new" publicationStatusEncoding="EASList" publicationStatus="published" repositoryEncoding="iso15511" scriptEncoding="iso15924">
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<control countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" languageEncoding="iso639-3" maintenanceStatusEncoding="EASList" maintenanceStatus="new" publicationStatusEncoding="EASList" publicationStatus="published" repositoryEncoding="iso15511" scriptEncoding="iso15924">
    [...]
-</control>]]></egXML>
+</control>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/attr-relationType.xml
+++ b/tei/shared/en/attr-relationType.xml
@@ -29,7 +29,7 @@
 		</relation>]]>
 		</egXML>
 		<egXML xmlns="http://www.tei-c.org/ns/Examples" type="eaf">
-			<![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#isOrWasPerformedBy" targetType="group">
+			<![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#performsOrPerformed" targetType="group">
 			<label>Obama Cabinet</label>
 		</relation>]]>
 		</egXML>

--- a/tei/shared/en/attr-relationTypeEncoding.xml
+++ b/tei/shared/en/attr-relationTypeEncoding.xml
@@ -7,7 +7,7 @@
 		<p>Relation Type Encoding</p>
 	</div>
 	<div type="summary">
-		<p>Specifies the authoritative source or rules for values used to identify the type of relation between the entity being described in the EAS instance and the related entity.</p>
+		<p>Specifies the authoritative source or rules for values used to identify the type of relation between between the related entity and the entity being described in the EAS instance.</p>
 	</div>
 	<div type="description">
 		<p><att>relationTypeEncoding</att> specifies the authoritative source or rules for values supplied in <att>relationType</att> within <gi>relation</gi>. If the value "EASList" is selected, <att>relationType</att> will be expected with the values "...". If the value "otherRelationTypeEncoding" is selected, an alternate code list should be specified in <gi>conventionDeclaration</gi>. This optional attribute is available only in <gi>control</gi>.</p>

--- a/tei/shared/en/attr-sourceReference.xml
+++ b/tei/shared/en/attr-sourceReference.xml
@@ -13,14 +13,15 @@
                   </p>
                </div>
                <div type="description">
-                  <p>The attribute can be used to reference any detailed information about the described entity with a source.</p>
+                  <p>The attribute can be used to link any detailed information about the described entity to a source.</p>
                   <p>The attribute is optionally available in elements which can contain text.</p>
                </div>
                <div type="datatype">
                   <p>IDREFS</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<sources>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<sources>
                     <source id="source1">
                     <reference>R. Greene, S.Cushman (ed.): The Princeton Handbook of World Poetries</reference>
                   </source>
@@ -28,6 +29,7 @@
                     [...]
                     <relation sourceReference="source1" maintenanceEventReference="me2" targetType="corporateBody" relationType="https://www.wikidata.org/wiki/Q166118">
                     <label valueURI="https://snaccooperative.org/ark:/99166/w63z1x39" vocabularySourceURI="https://snaccooperative.org">Princeton University</label>
-                  </relation>]]></egXML>
+                  </relation>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/attr-status.xml
+++ b/tei/shared/en/attr-status.xml
@@ -19,14 +19,14 @@
                   <p>token</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<nameEntry languageOfElement="de" preferredForm="true" status="authorized" localType="native">
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="eac"><![CDATA[<nameEntry languageOfElement="de" preferredForm="true" status="authorized" localType="native">
     <part localType="surname">Arendt</part>
     <part localType="firstname">Hannah</part>
 </nameEntry>]]></egXML>
-                  <egXML xml:lang="eng"><![CDATA[<dateRange>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<dateRange>
     <fromDate standardDate="2016-09">September 2016</fromDate>
     <toDate status="ongoing"/>
 </dateRange>]]></egXML>
-                  <egXML xml:lang="eng"><![CDATA[<date status="unknown"/>]]></egXML>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<date status="unknown"/>]]></egXML>
                </div>
             </div>

--- a/tei/shared/en/attr-style.xml
+++ b/tei/shared/en/attr-style.xml
@@ -19,7 +19,7 @@
       <p>normalizedString</p>
    </div>
    <div type="examples">
-      <egXML xml:lang="eng"><![CDATA[<p>
+      <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<p>
       During 1918, Robert Carlton Brown (1886-1959) traveled extensively in Mexico and Central America, writing for the U.S. Committee of Public Information in Santiago de Chile. In 1919, he moved with his wife, Rose Brown, to Rio de Janeiro, where they founded <span style="font-style:italic">Brazilian American</span>, a weekly magazine that ran until 1929. With Brown's mother, Cora, the Browns also established magazines in Mexico City and London: <span style="font-style:italic">Mexican American</span> (1924-1929) and <span style="font-style:italic">British American</span> (1926-1929).</p>]]></egXML>
    </div>
 </div>

--- a/tei/shared/en/attr-target.xml
+++ b/tei/shared/en/attr-target.xml
@@ -16,10 +16,10 @@
                   <p>IDREFS</p>
                </div>
                <div type="examples">
-                   <egXML xml:lang="eng" type="eac"><![CDATA[<occupations>
+                   <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="eac"><![CDATA[<occupations>
                     <occupation>
                     <term>Assistant examiner - level III</term>
-                    <placeName target="#place1">Bern</placeName>
+                    <placeName target="place1">Bern</placeName>
                   </occupation>
                   </occupations>
                     <places>
@@ -33,11 +33,11 @@
                   </address>
                   </place>
                   </places>]]></egXML>
-                  <egXML xml:lang="eng" type="ead"><![CDATA[<agents>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="ead"><![CDATA[<agents>
                     <agent>
                     <label>Schweizerisches Bundesarchiv</label>
                     <role>holdingInstitution</role>
-                    <placeName target="#place1">Bern</placeName>
+                    <placeName target="place1">Bern</placeName>
                   </agent>
                   </agents>
                     <places>
@@ -51,9 +51,9 @@
                   </address>
                   </place>
                   </places>]]></egXML>
-                 <egXML xml:lang="eng" type="eaf"><![CDATA[<description>
+                 <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="eaf"><![CDATA[<description>
                    <functionHistory>
-                   <p target="#lex1">Since 1862, liquidation also meant bringing criminal proceedings against directors and others who were alleged to have committed offences in relation to the company.</<p>
+                   <p target="lex1">Since 1862, liquidation also meant bringing criminal proceedings against directors and others who were alleged to have committed offences in relation to the company.</<p>
                  </functionHistory
                    <legislations>
                    <legislation id="lex1">Joint Stock Companies Act, 1856; Companies Act, 1862; Companies Act, 1900; Companies Act, 1907; Companies (Consolidation) Act, 1908; Companies Act, 1928; Companies Act, 1929; Companies Act, 1947</legislation>

--- a/tei/shared/en/attr-targetType.xml
+++ b/tei/shared/en/attr-targetType.xml
@@ -17,10 +17,10 @@
 		              <p>token</p>
 	             </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<relation targetType="resource">
+                  <egXML xml:lang="fre" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<relation targetType="resource">
 			  <label>Mémorial du colonel Gustafsson. - 1829</label>
 		  </relation>]]></egXML>
-                  <egXML xml:lang="eng"><![CDATA[<relation targetType="person" valueURI="https://d-nb.info/gnd/120636123" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<relation targetType="person" valueURI="https://d-nb.info/gnd/120636123" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
 			  <label>Sophie, Baden, Großherzogin, 1801-1865</label>
 		  </relation>]]></egXML>
                </div>

--- a/tei/shared/en/attr-unit.xml
+++ b/tei/shared/en/attr-unit.xml
@@ -16,6 +16,6 @@
                   <p>token</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<citedRange unit="page">1</citedRange>]]></egXML>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<citedRange unit="page">1</citedRange>]]></egXML>
                </div>
             </div>

--- a/tei/shared/en/attr-valueURI.xml
+++ b/tei/shared/en/attr-valueURI.xml
@@ -17,15 +17,15 @@
                   <p>anyURI</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                  <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples" type="eac"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
                     <label>Salzburg</label>
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#characteristicPlace" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Charakteristischer Ort</role>
 </place>]]></egXML>
-                 <egXML xml:lang="eng" type="ead"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                 <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples" type="ead"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
                     <label>Salzburg</label>
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#characteristicPlace" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Charakteristischer Ort</role>
 </place>]]></egXML>
-                 <egXML xml:lang="eng" type="eaf"><![CDATA[<nameEntry>
+                 <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="eaf"><![CDATA[<nameEntry>
                    <part valueURI="http://vocab.getty.edu/page/aat/300191862" vocabularySource="AAT">educating</part>
                  </nameEntry>]]></egXML>
                </div>

--- a/tei/shared/en/attr-vocabularySource.xml
+++ b/tei/shared/en/attr-vocabularySource.xml
@@ -10,20 +10,20 @@
                   <p>An attribute for identifying a vocabulary that is the source of the element's value.</p>
                </div>
                <div type="description">
-                  <p>Use the optional attribute to provide a name or title of the authority or vocabulary source of the element’s content given in <att>valueURI</att>. Available in all elements that can contain any type of entity. </p>
+                  <p>Use the optional <att>vocabularySource</att> attribute to provide a name or title of the authority or vocabulary source of the element’s content. Available in all elements that can contain any type of entity. </p>
                </div>
                <div type="datatype">
                   <p>token</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<occupation valueURI="https://d-nb.info/gnd/4053311-6" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                  <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples" type="eac"><![CDATA[<occupation valueURI="https://d-nb.info/gnd/4053311-6" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
                     <term>Schriftstellerin</term>
                   </occupation>]]></egXML>
-                 <egXML xml:lang="eng" type="ead"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                 <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples" type="ead"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
                     <label>Salzburg</label>
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#characteristicPlace" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Charakteristischer Ort</role>
 </place>]]></egXML>
-                 <egXML xml:lang="eng" type="eaf"><![CDATA[<nameEntry>
+                 <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="eaf"><![CDATA[<nameEntry>
                    <part valueURI="http://vocab.getty.edu/page/aat/300191862" vocabularySource="AAT" vocabularySourceURI="https://www.getty.edu/research/tools/vocabularies/aat/index.html">educating</part>
                  </nameEntry>]]></egXML>
                </div>

--- a/tei/shared/en/attr-vocabularySourceURI.xml
+++ b/tei/shared/en/attr-vocabularySourceURI.xml
@@ -18,15 +18,15 @@
                   <p>anyURI</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                  <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples" type="eac"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
                     <label>Salzburg</label>
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#characteristicPlace" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Charakteristischer Ort</role>
 </place>]]></egXML>
-                 <egXML xml:lang="eng" type="ead"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
+                 <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples" type="ead"><![CDATA[<place valueURI="https://d-nb.info/gnd/4076982-3" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">
                     <label>Salzburg</label>
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#characteristicPlace" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Charakteristischer Ort</role>
 </place>]]></egXML>
-                 <egXML xml:lang="eng" type="eaf"><![CDATA[<nameEntry>
+                 <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples" type="eaf"><![CDATA[<nameEntry>
                    <part valueURI="http://vocab.getty.edu/page/aat/300191862" vocabularySource="AAT" vocabularySourceURI="https://www.getty.edu/research/tools/vocabularies/aat/index.html">educating</part>
                  </nameEntry>]]></egXML>
                </div>

--- a/tei/shared/en/elem-objectXMLWrap.xml
+++ b/tei/shared/en/elem-objectXMLWrap.xml
@@ -56,7 +56,7 @@
                   </mods:mods>
                   </objectXMLWrap>]]></egXML>
                   <egXML xml:lang="en"><![CDATA[<objectXMLWrap>
-                    <tei:bibl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:text="http://www.tei-c.org/ns/1.0" xsi:schemaLocation="https://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" default="false">
+                    <tei:bibl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tei="http://www.tei-c.org/ns/1.0" xsi:schemaLocation="https://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" default="false">
                     <tei:title>
                     <tei:emph rend="italic">Paris d'hier et d'aujourd'hui</tei:emph>
                   </tei:title>

--- a/tei/shared/en/elem-objectXMLWrap.xml
+++ b/tei/shared/en/elem-objectXMLWrap.xml
@@ -44,7 +44,8 @@
                   <p>Optional, not repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="en"><![CDATA[<objectXMLWrap>
+                  <egXML xml:lang="en" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<objectXMLWrap>
                     <mods:mods xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/mods/v3/mods-3-3.xsd">
                     <mods:titleInfo>
                     <mods:title>Artisti trentini tra le due guerre</mods:title>
@@ -54,8 +55,10 @@
                     <mods:namePart type="family">Boschiero</mods:namePart>
                   </mods:name>
                   </mods:mods>
-                  </objectXMLWrap>]]></egXML>
-                  <egXML xml:lang="en"><![CDATA[<objectXMLWrap>
+                  </objectXMLWrap>]]>
+                  </egXML>
+                  <egXML xml:lang="en" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<objectXMLWrap>
                     <tei:bibl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tei="http://www.tei-c.org/ns/1.0" xsi:schemaLocation="https://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" default="false">
                     <tei:title>
                     <tei:emph rend="italic">Paris d'hier et d'aujourd'hui</tei:emph>
@@ -66,14 +69,17 @@
                     <tei:name>Yann Arthus-Bertrand</tei:name>
                   </tei:respStmt>
                   </tei:bibl>
-                  </objectXMLWrap>]]></egXML>
-                  <egXML xml:lang="en"><![CDATA[<objectXMLWrap>
-                    <note xmlns="">
+                  </objectXMLWrap>]]>
+                  </egXML>
+                  <egXML xml:lang="en" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<objectXMLWrap>
+                    <note>
                     <to>Tove</to>
                     <from>Jani</from>
                     <heading>Reminder</heading>
                     <body>Don't forget me this weekend!</body>
                   </note>
-                  </objectXMLWrap>]]></egXML>
+                  </objectXMLWrap>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-otherAgencyCode.xml
+++ b/tei/shared/en/elem-otherAgencyCode.xml
@@ -66,7 +66,7 @@
    <agencyName>
       State University of New York at Buffalo, Archives
    </agencyName>
-   <otherAgencyCode status="authorized" valueURI="http://id.loc.gov/vocabulary/organizations/nbuuar" vocabularySource="MARC Code List for Organizations" vocabularySourceURI="https://www.loc.gov/marc/organizations/">
+   <otherAgencyCode status="authorized" valueURI="http://id.loc.gov/vocabulary/organizations/nbuuar" vocabularySource="MARC Code List for Organizations" vocabularySourceURI="http://id.loc.gov/vocabulary/organizations">
       NBuU-AR
    </otherAgencyCode>
 </maintenanceAgency>]]></egXML>
@@ -77,7 +77,7 @@
    <agencyName>
       Beinecke Rare Book and Manuscript Library
    </agencyName>
-   <otherAgencyCode status="authorized" valueURI="https://id.loc.gov/vocabulary/organizations/ctybr" vocabularySource="MARC Code List for Organizations" vocabularySourceURI="https://www.loc.gov/marc/organizations/">
+   <otherAgencyCode status="authorized" valueURI="https://id.loc.gov/vocabulary/organizations/ctybr" vocabularySource="MARC Code List for Organizations" vocabularySourceURI="http://id.loc.gov/vocabulary/organizations">
       CtY-BR
    </otherAgencyCode>
    <otherAgencyCode status="alternative" valueURI="https://www.wikidata.org/wiki/Q814779" vocabularySource="Wikidata" vocabularySourceURI="https://www.wikidata.org/">

--- a/tei/shared/en/elem-otherAgencyCode.xml
+++ b/tei/shared/en/elem-otherAgencyCode.xml
@@ -80,7 +80,7 @@
    <otherAgencyCode status="authorized" valueURI="https://id.loc.gov/vocabulary/organizations/ctybr" vocabularySource="MARC Code List for Organizations" vocabularySourceURI="http://id.loc.gov/vocabulary/organizations">
       CtY-BR
    </otherAgencyCode>
-   <otherAgencyCode status="alternative" valueURI="https://www.wikidata.org/wiki/Q814779" vocabularySource="Wikidata" vocabularySourceURI="https://www.wikidata.org/">
+   <otherAgencyCode status="alternative" valueURI="http://www.wikidata.org/entity/Q814779" vocabularySource="Wikidata" vocabularySourceURI="https://www.wikidata.org/">
       Q814779
    </otherAgencyCode>
 </maintenanceAgency>]]></egXML>

--- a/tei/shared/en/elem-otherAgencyCode.xml
+++ b/tei/shared/en/elem-otherAgencyCode.xml
@@ -59,7 +59,8 @@
                   <p>Optional, repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<maintenanceAgency>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<maintenanceAgency>
    <agencyCode status="authorized" vocabularySource="ISIL" vocabularySourceURI="http://id.loc.gov/vocabulary/identifiers/isil">
       US-nbuuar
    </agencyCode>
@@ -69,8 +70,10 @@
    <otherAgencyCode status="authorized" valueURI="http://id.loc.gov/vocabulary/organizations/nbuuar" vocabularySource="MARC Code List for Organizations" vocabularySourceURI="http://id.loc.gov/vocabulary/organizations">
       NBuU-AR
    </otherAgencyCode>
-</maintenanceAgency>]]></egXML>
-                  <egXML xml:lang="eng"><![CDATA[<maintenanceAgency>
+</maintenanceAgency>]]>
+                  </egXML>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<maintenanceAgency>
    <agencyCode status="authorized" vocabularySource="ISIL" vocabularySourceURI="http://id.loc.gov/vocabulary/identifiers/isil">
       US-ctybr
    </agencyCode>
@@ -83,6 +86,7 @@
    <otherAgencyCode status="alternative" valueURI="http://www.wikidata.org/entity/Q814779" vocabularySource="Wikidata" vocabularySourceURI="https://www.wikidata.org/">
       Q814779
    </otherAgencyCode>
-</maintenanceAgency>]]></egXML>
+</maintenanceAgency>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-otherRecordId.xml
+++ b/tei/shared/en/elem-otherRecordId.xml
@@ -55,7 +55,11 @@
                   <p>Optional, repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<otherRecordId valueURI="https://pares.mcu.es/ParesBusquedas20/catalogo/autoridad/140149" vocabularySource="PARES">140149</otherRecordId>]]></egXML>
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<otherRecordId localType="original" localTypeDeclarationReference="identifierTypes">AUBT-ISAAR-C-002</otherRecordId>]]></egXML>
+                  <egXML xml:lang="eng" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<otherRecordId valueURI="https://pares.mcu.es/ParesBusquedas20/catalogo/autoridad/140149" vocabularySource="PARES">140149</otherRecordId>]]>
+                  </egXML>
+                  <egXML xml:lang="eng" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<otherRecordId localType="original" localTypeDeclarationReference="identifierTypes">AUBT-ISAAR-C-002</otherRecordId>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-p.xml
+++ b/tei/shared/en/elem-p.xml
@@ -49,7 +49,7 @@
                   </p>
                </div>
                <div type="description">
-                  <p>Use <gi>p</gi> for blocks of text. A paragraph may be a subdivision of a larger composition or it may exist alone. It is usually typographically distinguished: A line space is often left blank before it; the text begins on a new line; and the first letter of the first word may be indented, enlarged, or both.</p>
+                  <p>Use <gi>p</gi> for blocks of text. A paragraph may be a subdivision of a larger composition or it may exist alone. It is usually typographically distinguished: a line space is often left blank before it; the text begins on a new line; and the first letter of the first word may be indented, enlarged, or both.</p>
                </div>
                <div type="availability">
                   <p>Within <gi>descriptiveNote</gi>: required, repeatable.</p>

--- a/tei/shared/en/elem-p.xml
+++ b/tei/shared/en/elem-p.xml
@@ -57,24 +57,30 @@
                   <p>In all parents except <gi>descriptiveNote</gi>, the encoder must choose between using one or more <gi>p</gi> elements that are defined within the current EAS schema, or using a <gi>formattingExtention</gi> element (to wrap XHTML content) for more complex formatting.</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<biogHist>
+                  <egXML xml:lang="eng" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<biogHist>
    <p>
       Robert Carlton Brown (1886-1959) was a writer, editor, publisher, and traveler. From 1908 to 1917, he wrote poetry and prose for numerous magazines and newspapers in New York City, publishing two pulp novels, <span style="font-style:italic">What Happened to Mary</span> and <span style="font-style:italic">The Remarkable Adventures of Christopher Poe</span> (1913), and one volume of poetry, <span style="font-style:italic">My Marjonary</span> (1916).
    </p>
    <p>
       During 1918, he traveled extensively in Mexico and Central America, writing for the U.S. Committee of Public Information in Santiago de Chile. In 1919, he moved with his wife, Rose Brown, to Rio de Janeiro, where they founded <span style="font-style:italic">Brazilian American</span>, a weekly magazine that ran until 1929. With Brown's mother, Cora, the Browns also established magazines in Mexico City and London: <span style="font-style:italic">Mexican American</span> (1924-1929) and <span style="font-style:italic">British American</span> (1926-1929).
    </p>
-</biogHist>]]></egXML>
-                 <egXML xml:lang="eng" type="ead"><![CDATA[<biogHist>
+</biogHist>]]>
+                  </egXML>
+                 <egXML xml:lang="eng" type="ead" xmlns="http://www.tei-c.org/ns/Examples">
+                   <![CDATA[<biogHist>
    <p>
       Robert Carlton Brown (1886-1959) was a writer, editor, publisher, and traveler. From 1908 to 1917, he wrote poetry and prose for numerous magazines and newspapers in New York City, publishing two pulp novels, <span style="font-style:italic">What Happened to Mary</span> and <span style="font-style:italic">The Remarkable Adventures of Christopher Poe</span> (1913), and one volume of poetry, <span style="font-style:italic">My Marjonary</span> (1916).
    </p>
    <p>
       During 1918, he traveled extensively in Mexico and Central America, writing for the U.S. Committee of Public Information in Santiago de Chile. In 1919, he moved with his wife, Rose Brown, to Rio de Janeiro, where they founded <span style="font-style:italic">Brazilian American</span>, a weekly magazine that ran until 1929. With Brown's mother, Cora, the Browns also established magazines in Mexico City and London: <span style="font-style:italic">Mexican American</span> (1924-1929) and <span style="font-style:italic">British American</span> (1926-1929).
    </p>
-</biogHist>]]></egXML>
-                 <egXML xml:lang="eng" type="eaf"><![CDATA[<functionHistory>
+</biogHist>]]>
+                 </egXML>
+                 <egXML xml:lang="eng" type="eaf" xmlns="http://www.tei-c.org/ns/Examples">
+                   <![CDATA[<functionHistory>
 <p>In 1968 Yale stated they will admit 500 women into Yale College in the following Fall. The Planning Committee on Coeducation (1968-1969) oversaw every aspect of planning. In 1969, the University Committee on Coeducation was formed. The Committee continued to oversee the transition and facilitate integration of the female students. The Coeducation Office was also established to facilitate programs initiated by the Committee and to serve as a resource for the undergraduates, as well as graduate students, other women on campus, and administrators. Wasserman left Yale in 1972. Mary Arnstein became Acting Special Assistant to the President and chair of the University Committee on Coeducation. The Committee voted to terminate the position of Special Assistant and the Coeducation Office and transfer responsibilities to existing offices and a reorganized University Committee on the Education of Women in 1973. Some functions of the Coeducation Office were assumed by the new Office on the Education of Women. The University Committee on the Education of Women served as an advisory group to the president on issues related to women at Yale until 1977.</p>
-</functionHistory>]]></egXML>
+</functionHistory>]]>
+                 </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-part.xml
+++ b/tei/shared/en/elem-part.xml
@@ -66,7 +66,7 @@
                   <egXML xml:lang="eng" type="eac"><![CDATA[<nameEntry conventionDeclarationReference="cd1" preferredForm="true">
                     <part>Provence-Alpes-Côte d'Azur</part>
                   </nameEntry>]]></egXML>
-                 <egXML xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<!-- The following example has been adapted from the EADiva Tag Libray by Ruth Kitchin Tillman, https://eadiva.com/filedesc/ -->
+                 <egXML xml:lang="en" type="ead"><![CDATA[<!-- The following example has been adapted from the EADiva Tag Libray by Ruth Kitchin Tillman, https://eadiva.com/filedesc/ -->
                    <ead>
                    <control>[...]</control>
                    <findAidDesc href="https://archives.piecemaking.edu/finding-aids/quilting-technologies-department/quilting-technologies-department.xml" linkTitle="Download the encoded finding aid" linkRole="text/xml">

--- a/tei/shared/en/elem-part.xml
+++ b/tei/shared/en/elem-part.xml
@@ -59,14 +59,19 @@
                   <p>Required, repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<nameEntry languageOfElement="de" preferredForm="true" status="authorized" localType="native">
+                  <egXML xml:lang="eng" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<nameEntry languageOfElement="de" preferredForm="true" status="authorized" localType="native">
                     <part localType="surname">Arendt</part>
                     <part localType="firstname">Hannah</part>
-                  </nameEntry>]]></egXML>
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<nameEntry conventionDeclarationReference="cd1" preferredForm="true">
+                  </nameEntry>]]>
+                  </egXML>
+                  <egXML xml:lang="eng" type="eac"  xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<nameEntry conventionDeclarationReference="cd1" preferredForm="true">
                     <part>Provence-Alpes-Côte d'Azur</part>
-                  </nameEntry>]]></egXML>
-                 <egXML xml:lang="en" type="ead"><![CDATA[<!-- The following example has been adapted from the EADiva Tag Libray by Ruth Kitchin Tillman, https://eadiva.com/filedesc/ -->
+                  </nameEntry>]]>
+                  </egXML>
+                 <egXML xml:lang="en" type="ead" xmlns="http://www.tei-c.org/ns/Examples">
+                   <![CDATA[<!-- The following example has been adapted from the EADiva Tag Libray by Ruth Kitchin Tillman, https://eadiva.com/filedesc/ -->
                    <ead>
                    <control>[...]</control>
                    <findAidDesc href="https://archives.piecemaking.edu/finding-aids/quilting-technologies-department/quilting-technologies-department.xml" linkTitle="Download the encoded finding aid" linkRole="text/xml">
@@ -82,6 +87,7 @@
                    <part localType="issueNumber" localTypeDeclarationReference="titles">13</part>
                  </title>
                    [...]
-                 </findAidDesc>]]></egXML>
+                 </findAidDesc>]]>
+                 </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-place.xml
+++ b/tei/shared/en/elem-place.xml
@@ -17,7 +17,7 @@
   <label>contact</label>
   <item>0..n</item>
   <label>date or dateRange or dateSet</label>
-  <item>0..n</item>
+  <item>0..1</item>
   <label>descriptiveNote</label>
   <item>0..1</item>
   <label>geographicCoordinates</label>
@@ -86,21 +86,24 @@
                   <p type="ead">Within <gi>findAidDesc</gi>: optional, repeatable.</p>
                </div>
                <div type="examples">
-                 <egXML xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<places>
+                 <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                   <![CDATA[<places>
                    <place placeType="firstOrderAdministrativeDivision">
-                   <label valueURI="https://www.geonames.org/2152274/state-of-queensland.html"vocabularySource="GeoNames">Queensland</label>
+                   <label valueURI="https://www.geonames.org/2152274/state-of-queensland.html"  vocabularySource="GeoNames">Queensland</label>
                  </place>
                    <place placeType="reef">
                    <label valueURI="https://www.geonames.org/2164628/great-barrier-reef.html" vocabularySource="GeoNames">Great Barrier Reef</label>
                  </place>
                  </places>]]>
                  </egXML> 
-                 <egXML xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<place>
+                 <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                   <![CDATA[<place>
                    <label vocabularySource="local">East Side (Buffalo, N.Y.)</label>
                    <geographicCoordinates coordinateSystem="WGS84">N 42°53′48" W 78°50′2"</geographicCoordinates
                  </place>]]>
                  </egXML>
-                 <egXML xmlns="http://www.tei-c.org/ns/Examples" type="ead"><![CDATA[<c level="file">
+                 <egXML xmlns="http://www.tei-c.org/ns/Examples" type="ead">
+                   <![CDATA[<c level="file">
                    <identificationData>
                    <unitTitle>Lettera di Iacopo II Barozzi a Pietro Gradenigo 49<span style="vertical-align: super">o</span> doge della Repubblica di Venezia</unitTitle>
                    <unitDate>
@@ -149,10 +152,13 @@
                    <role valueURI="https://www.ica.org/standards/RiC/ontology#isOrWasSubjectOf" vocabularySource="RiC-O">soggetto</role>
                  </place>
                  </places>
-                 </c>]]></egXML>
-                 <egXML xmlns="http://www.tei-c.org/ns/Examples" type="eac"><![CDATA[<place placeType="county">
+                 </c>]]>
+                 </egXML>
+                 <egXML xmlns="http://www.tei-c.org/ns/Examples" type="eac">
+                   <![CDATA[<place placeType="county">
                    <label valueURI="http://vocab.getty.edu/page/tgn/7008153" vocabularySource="tgn" vocabularySourceURI="https://www.getty.edu/research/tools/vocabularies/tgn/index.html">Kent</label>
                    <role>Residence</role>
-                 </place>]]></egXML>
+                 </place>]]>
+                 </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-placeName.xml
+++ b/tei/shared/en/elem-placeName.xml
@@ -71,7 +71,7 @@
                   <p>Optional, repeatable</p>
                </div>
                <div type="examples">
-		       <egXML xmlns="http://www.tei-c.org/ns/Examples" type="eac">
+		       <egXML xml:lang="en" type="eac">
 			       <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#FamilyRelation" targetType="person">
 			       <label>Marie Skłodowska-Curie</label>
 			       <dateRange>
@@ -81,8 +81,8 @@
 			       <placeName valueURI="https://www.geonames.org/2988507/paris.html" vocabularySource="GeoNames">Paris</placeName>
 			       <role valueURI="https://www.ica.org/standards/RiC/ontology#hasOrHadSpouse" vocabularySourceURI="https://www.ica.org/standards/RiC/ontology">Esposa</role>
 		       </relation>]]>
-		</egXML>
-                            <egXML xmlns="http://www.tei-c.org/ns/Examples" type="eaf">
+		     </egXML>
+                            <egXML xml:lang="en" type="eaf">
 			       <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#OccupationType" targetType="person">
                                 <label>Marie Skłodowska-Curie</label>
                                 <dateRange>
@@ -93,7 +93,7 @@
                                 <role valueURI="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType" vocabularySourceURI="https://www.ica.org/standards/RiC/ontology">Cátedra de Física</role>
                             </relation>]]>
 		</egXML>
-                            <egXML xmlns="http://www.tei-c.org/ns/Examples" type="ead">
+                            <egXML xml:lang="en" type="ead">
 			       <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#CreationRelation" targetType="person">
                                 <label>Marie Skłodowska-Curie</label>
                                 <date>1903</date>

--- a/tei/shared/en/elem-placeName.xml
+++ b/tei/shared/en/elem-placeName.xml
@@ -71,7 +71,7 @@
                   <p>Optional, repeatable</p>
                </div>
                <div type="examples">
-		       <egXML xml:lang="en" type="eac">
+		       <egXML xml:lang="en" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
 			       <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#FamilyRelation" targetType="person">
 			       <label>Marie Skłodowska-Curie</label>
 			       <dateRange>
@@ -82,7 +82,7 @@
 			       <role valueURI="https://www.ica.org/standards/RiC/ontology#hasOrHadSpouse" vocabularySourceURI="https://www.ica.org/standards/RiC/ontology">Esposa</role>
 		       </relation>]]>
 		     </egXML>
-                            <egXML xml:lang="en" type="eaf">
+                            <egXML xml:lang="en" type="eaf" xmlns="http://www.tei-c.org/ns/Examples">
 			       <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#OccupationType" targetType="person">
                                 <label>Marie Skłodowska-Curie</label>
                                 <dateRange>
@@ -93,7 +93,7 @@
                                 <role valueURI="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType" vocabularySourceURI="https://www.ica.org/standards/RiC/ontology">Cátedra de Física</role>
                             </relation>]]>
 		</egXML>
-                            <egXML xml:lang="en" type="ead">
+                            <egXML xml:lang="en" type="ead" xmlns="http://www.tei-c.org/ns/Examples">
 			       <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#CreationRelation" targetType="person">
                                 <label>Marie Skłodowska-Curie</label>
                                 <date>1903</date>

--- a/tei/shared/en/elem-places.xml
+++ b/tei/shared/en/elem-places.xml
@@ -60,7 +60,8 @@
                   <p>Optional, not repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<places>
+                  <egXML xml:lang="ger" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<places>
                     <place placeType="populatedPlace">
                     <label valueURI="https://d-nb.info/gnd/4057648-6" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">Stockholm</label>
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#placeOfBirth" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Geburtsort</role>
@@ -69,8 +70,10 @@
                     <label valueURI="https://d-nb.info/gnd/4051594-1" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">Sankt Gallen</label>	
                     <role valueURI="https://d-nb.info/standards/elementset/gnd#placeOfDeath" vocabularySource="GNDO" vocabularySourceURI="https://d-nb.info/standards/elementset/gnd#">Sterbeort</role>
                   </place>
-                  </places>]]></egXML>
-                 <egXML xml:lang="eng" type="ead"><![CDATA[<places>
+                  </places>]]>
+                  </egXML>
+                 <egXML xml:lang="ita" type="ead" xmlns="http://www.tei-c.org/ns/Examples">
+                   <![CDATA[<places>
                    <place placeType="populatedPlace">
                    <label>Treviso</label>
                    <role valueURI="https://schema.org/serviceLocation" vocabularySource="schema.org">sala lettura</role>
@@ -91,6 +94,7 @@
                    <label valueURI="https://www.geonames.org/6697802/crete.html" vocabularySource="GeoNames">Regno de Càndia</label>
                    <role valueURI="https://www.ica.org/standards/RiC/ontology#isOrWasSubjectOf" vocabularySource="RiC-O">soggetto</role>
                  </place>
-                 </places>]]></egXML>
+                 </places>]]>
+                 </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-recordId.xml
+++ b/tei/shared/en/elem-recordId.xml
@@ -45,8 +45,8 @@
                   <p>Required, not repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="en"><![CDATA[<recordId>F10219</recordId>]]></egXML>
-                  <egXML xml:lang="en"><![CDATA[<recordId>ES-28079-PARES-AUT-140149</recordId>]]></egXML>
-                  <egXML xml:lang="en"><![CDATA[<recordId>DE-1981_C002</recordId>]]></egXML>
+                  <egXML xml:lang="en" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<recordId>F10219</recordId>]]></egXML>
+                  <egXML xml:lang="en" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<recordId>ES-28079-PARES-AUT-140149</recordId>]]></egXML>
+                  <egXML xml:lang="en" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<recordId>DE-1981_C002</recordId>]]></egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-reference.xml
+++ b/tei/shared/en/elem-reference.xml
@@ -78,20 +78,25 @@
       <p type="ead">Within <gi>abstract</gi>, <gi>container</gi>, <gi>eventDescription</gi>, <gi>formAvailableId</gi>, <gi>genreForm</gi>, <gi>head</gi>, <gi>otherIdentificationData</gi>, <gi>p</gi>, <gi>physicalFacet</gi>, <gi>textualDate</gi>, <gi>unitId</gi>, <gi>unitTitle</gi>: optional, repeatable</p>
    </div>
    <div type="examples">
-      <egXML xml:lang="eng"><![CDATA[<source>
+      <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+         <![CDATA[<source>
          <reference href="https://de.wikipedia.org/wiki/Gustav_IV._Adolf_(Schweden)">Wikipedia</reference>
       </source>]]>
       </egXML>
-      <egXML xml:lang="eng"><![CDATA[<conventionDeclaration>
+      <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+         <![CDATA[<conventionDeclaration>
          <reference href="https://www.loc.gov/aba/rda/">Resource Description and Access</reference>
          <shortCode>RDA</shortCode>
-      </conventionDeclaration>]]></egXML>
-      <egXML xml:lang="eng"><![CDATA[<maintenanceEvent maintenanceEventType="revised">
+      </conventionDeclaration>]]>
+      </egXML>
+      <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+         <![CDATA[<maintenanceEvent maintenanceEventType="revised">
          <agent>
          <label>T. Baker</label>
       </agent>
          <eventDateTime standardDateTime="2022-10">October 2022</eventDateTime>
          <eventDescription>The archival description encoded in this document has been reviewed and, where necessary, updated following the <reference href="https://guides.library.yale.edu/reparativearchivaldescription">Reparative Archival Description Working Group: Guiding Principles</reference>.</eventDescription>
-      </maintenanceEvent>]]></egXML>
+      </maintenanceEvent>]]>
+      </egXML>
    </div>
 </div>

--- a/tei/shared/en/elem-relation.xml
+++ b/tei/shared/en/elem-relation.xml
@@ -90,15 +90,16 @@
       </relation>]]>
 		</egXML>
       <egXML xmlns="http://www.tei-c.org/ns/Examples" type="eaf">
-         <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#OccupationType" targetType="person">
+         <![CDATA[<!-- This is not consistent, as OccupationType is not a relation in RiC-O. The relation element should directly point to the rico:hasOrHadOccupationOfType that the role element refers to <relation relationType="https://www.ica.org/standards/RiC/ontology#OccupationType" targetType="person">-->
+		  <relation relationType="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType" targetType="person">
          <label>Marie Skłodowska-Curie</label>
          <dateRange>
          <fromDate>1908</fromDate>
          <toDate>1934</toDate>
       </dateRange>
          <placeName valueURI="https://www.geonames.org/2988507/paris.html" vocabularySource="GeoNames">Paris</placeName>
-         <role valueURI="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType" vocabularySourceURI="https://www.ica.org/standards/RiC/ontology">Cátedra de Física</role>
-      </relation>]]>
+         <!-- <role valueURI="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType" vocabularySourceURI="https://www.ica.org/standards/RiC/ontology">Cátedra de Física</role>
+      </relation>]]>-->
 		</egXML>
       <egXML xmlns="http://www.tei-c.org/ns/Examples" type="ead">
          <![CDATA[<relation relationType="https://www.ica.org/standards/RiC/ontology#CreationRelation" targetType="person">

--- a/tei/shared/en/elem-relations.xml
+++ b/tei/shared/en/elem-relations.xml
@@ -56,7 +56,8 @@
                   <p>Optional, not repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng" type="eac"><![CDATA[<relations>
+                  <egXML xmlns="http://www.tei-c.org/ns/Examples" type="eac">
+                    <![CDATA[<relations>
                     <relation relationType="family" targetType="person">
                     <label valueURI="https://d-nb.info/gnd/119067159X" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">Arendt, Max (1843-1913)</label>
                     <role>grandfather</role>
@@ -69,8 +70,10 @@
                     <label valueURI="https://d-nb.info/gnd/1190671301" vocabularySource="GND" vocabularySourceURI="https://d-nb.info/gnd/">Arendt, Paul (1873-1913)</label>
                     <role>father</role>
                   </relation>
-                  </relations>]]></egXML>
-                 <egXML xmlns="http://www.tei-c.org/ns/Examples" type="ead"><![CDATA[<relatedMaterial>
+                  </relations>]]>
+                  </egXML>
+                 <egXML xmlns="http://www.tei-c.org/ns/Examples" type="ead">
+                   <![CDATA[<relatedMaterial>
                    <abstract>Several genealogies and biographies of the Smith family have been published and are held in the Rare Books Department.</abstract>
                    <relations>
                    <relation targetType="resource">

--- a/tei/shared/en/elem-relationship.xml
+++ b/tei/shared/en/elem-relationship.xml
@@ -63,7 +63,7 @@
 		<p>The <gi>relationship</gi> element contains a textual description of the relation. It is recommended that values used in <gi>relationship</gi> be taken from an authorized vocabulary.</p>
 	</div>
 	<div type="attributeusage">
-		<p>Use <att>valueURI</att> to provide a number, code, or string (e.g., URI) that uniquely identifies the genre or form in a controlled vocabulary, taxonomy, ontology, or other knowledge organization system. Use <att>vocabularySource</att> and/or <att>vocabularySourceURI</att> to name and/or point to the organization system used.</p>
+		<p>Use <att>valueURI</att> to provide a number, code, or string (e.g., URI) that uniquely identifies the relationship in a controlled vocabulary, taxonomy, ontology, or other knowledge organization system. Use <att>vocabularySource</att> and/or <att>vocabularySourceURI</att> to name and/or point to the organization system used.</p>
 	</div>	
 	<div type="seealso">
 		<p>Use <gi>role</gi> to more specifically indicate the role of the related entity towards the entity being described in the EAS instance respectively towards the EAS instance itself.</p>
@@ -72,7 +72,7 @@
 		<p>Optional, Repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng">
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
 			<![CDATA[<maintenanceHistory>
 			<maintenanceEvent id="me1">
 			<agent>

--- a/tei/shared/en/elem-rightsDeclaration.xml
+++ b/tei/shared/en/elem-rightsDeclaration.xml
@@ -60,13 +60,15 @@
                   <p>Optional, repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<rightsDeclaration>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<rightsDeclaration>
    <reference href="https://creativecommons.org/publicdomain/zero/1.0/deed.de">
       Creative Commons CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
    </reference>
    <shortCode>
       CC0 1.0
    </shortCode>
-</rightsDeclaration>]]></egXML>
+</rightsDeclaration>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-role.xml
+++ b/tei/shared/en/elem-role.xml
@@ -62,7 +62,7 @@
 		<p>Optional, repeatable</p>
 	</div>
 	<div type="examples">
-		<egXML xml:lang="eng">
+		<egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
 			<![CDATA[<maintenanceHistory>
 			<maintenanceEvent id="me1">
 			<agent>

--- a/tei/shared/en/elem-shortCode.xml
+++ b/tei/shared/en/elem-shortCode.xml
@@ -36,27 +36,31 @@
                </div>
                <div type="description">
                   <p>Use <gi>shortCode</gi> within <gi>conventionDeclaration</gi> or <gi>localTypeDeclaration</gi> to identify the shortened form, acronym, or code for a thesaurus, controlled vocabulary, or another standard used in creating the EAS description. Use within <gi>rightsDeclaration</gi> to provide an abbreviated name for the rights statement.</p>
-                  <p>To improve interoperability, it is recommended that the value be selected from an authorized list of codes such as the MARC Code List (http://www.loc.gov/marc/sourcelist/).</p>
+                  <p>To improve interoperability, it is recommended that the value be selected from an authorized list of codes such as the MARC Field Index to Source Code Usage (http://www.loc.gov/marc/sourcelist/).</p>
                </div>
                <div type="availability">
                   <p>Optional, not repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<conventionDeclaration id="conventiondeclaration1">
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<conventionDeclaration id="conventiondeclaration1">
    <reference>
       Anglo-American Cataloging Rules, Revised
    </reference>
    <shortCode>
       AACR2
    </shortCode>
-</conventionDeclaration>]]></egXML>
-                  <egXML xml:lang="eng"><![CDATA[<rightsDeclaration>
+</conventionDeclaration>]]>
+                  </egXML>
+                  <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<rightsDeclaration>
    <reference href="https://creativecommons.org/licenses/by/4.0/">
       Creative Commons Attribution 4.0 International Public License
    </reference>
    <shortCode>
       CC BY
    </shortCode>
-</rightsDeclaration>]]></egXML>
+</rightsDeclaration>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-source.xml
+++ b/tei/shared/en/elem-source.xml
@@ -71,7 +71,8 @@
                   <p>Required, repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<sources>
+                  <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<sources>
                     <source href="https://de.wikipedia.org/wiki/Gustav_IV._Adolf_(Schweden)">
                     <reference>Wikipedia-Seite zu Gustav IV. Adolf</reference>
                   </source>
@@ -81,6 +82,7 @@
                     <p>Stand: 03.12.2020</p>
                   </descriptiveNote>
                   </source>
-                  </sources>]]></egXML>
+                  </sources>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-sources.xml
+++ b/tei/shared/en/elem-sources.xml
@@ -48,7 +48,8 @@
                   <p>Optional, not repeatable</p>
                </div>
                <div type="examples">
-                  <egXML xml:lang="eng"><![CDATA[<sources>
+                  <egXML xml:lang="ger" xmlns="http://www.tei-c.org/ns/Examples">
+                    <![CDATA[<sources>
                     <source>
                     <reference>Provenienzmerkmal</reference>
                   </source>
@@ -58,6 +59,7 @@
                     <p>Stand: 31.07.2018</p>
                   </descriptiveNote>
                   </source>
-                  </sources>]]></egXML>
+                  </sources>]]>
+                  </egXML>
                </div>
             </div>

--- a/tei/shared/en/elem-span.xml
+++ b/tei/shared/en/elem-span.xml
@@ -51,12 +51,12 @@
    <div type="description">
       <p><gi>span</gi> is an optional formatting element for distinguishing words or phrases that are intentionally stressed or emphasized for linguistic effect or identifying some qualities of the words or phrases.</p>
    </div>
-   <div type="attributeusage"><p>Use the optional <att>style</att> attribute to affect an arbitrary stylistic difference.</p>
+   <div type="attributeusage"><p>Use the optional <att>style</att> attribute to specify an arbitrary stylistic difference.</p>
    </div>
    <div type="availability">
       <p>Optional, repeatable</p>
    </div>
    <div type="examples">
-      <egXML xml:lang="eng"><![CDATA[<p>Robert Carlton Brown (1886-1959) was a writer, editor, publisher, and traveler. From 1908 to 1917, he wrote poetry and prose for numerous magazines and newspapers in New York City, publishing two pulp novels, <span style="font-style:italic">What Happened to Mary</span> and <span style="font-style:italic">The Remarkable Adventures of Christopher Poe</span> (1913), and one volume of poetry, <span style="font-style:italic">My Marjonary</span> (1916).</p>]]></egXML>
+      <egXML xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[<p>Robert Carlton Brown (1886-1959) was a writer, editor, publisher, and traveler. From 1908 to 1917, he wrote poetry and prose for numerous magazines and newspapers in New York City, publishing two pulp novels, <span style="font-style:italic">What Happened to Mary</span> and <span style="font-style:italic">The Remarkable Adventures of Christopher Poe</span> (1913), and one volume of poetry, <span style="font-style:italic">My Marjonary</span> (1916).</p>]]></egXML>
    </div>
 </div>

--- a/tei/shared/en/elem-term.xml
+++ b/tei/shared/en/elem-term.xml
@@ -50,7 +50,7 @@
                   <p>Required, repeatable</p>
                </div>
                <div type="examples">
-                  <egXML type="eac" xml:lang="eng">
+                  <egXML type="eac" xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
                     <![CDATA[<functionPerformed>
                     <term>Estate ownership</term>
                     <descriptiveNote>
@@ -58,13 +58,13 @@
                   </descriptiveNote>
                   </functionPerformed>]]>
                   </egXML>
-                  <egXML xml:lang="eng" type="eac">
+                  <egXML xml:lang="eng" type="eac" xmlns="http://www.tei-c.org/ns/Examples">
                     <![CDATA[<legalStatus>
                     <term scriptOfElement="Latn">Organismo de la Administracion Central del Estado</term>
                     <date standardDate="1769">1769</date>
                   </legalStatus>]]>
                   </egXML>
-                  <egXML type="eac" xml:lang="eng">
+                  <egXML type="eac" xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
                     <![CDATA[<mandate>
                     <term>Minnesota. Executive Session Laws 1919 c49</term>
                     <dateRange>
@@ -76,7 +76,7 @@
                   </descriptiveNote>
                   </mandate>]]>
                   </egXML>
-                  <egXML type="eac" xml:lang="eng">
+                  <egXML type="eac" xml:lang="eng" xmlns="http://www.tei-c.org/ns/Examples">
                     <![CDATA[<occupation>
                     <term>Teacher</term></occupation>]]>
                   </egXML>


### PR DESCRIPTION
Whenever it was missing, added the  `xmlns="http://www.tei-c.org/ns/Examples` attribute to `egXML`.

elem-objectXMLWrap.xml: fixed the xml namespace in the TEI example (was 'xmlns:text')

elem-otherAgencyCode.xml: fixed the value of@vocabularySourceURI for the Marc Code List for Organizations, and a Wikidata URI

elem-p.xml: typo

elem-part.xml: fixed the attributes of the EAD example

elem-physicalDescription.xml: typo, and removed two words.

elem-physicalFacet.xml: typo and change in the value of @valueURI in the examples

elem-physicalOrTechnicalRequirements.xml: enhanced the sentence in the summary; fixed typos.

elem-place.xml: fixed the cardinality of 'date or dateRange or dateSet' (changed to 0..1); indented the examples in order for them to be readable in the output.

elem-places.xml: fixed the language of the examples.

elem-relatedMaterial.xml: added the xmlns:html attribute to the html:div element in the formattingExtension example.

elem-relation.xml : commented the role element in the eaf example, and changed the value of @valueURI for the relation example.

elem-relationship.xml: changed a word in the attribute usage section.

elem-separatedMaterial.xml : adjusted the first sentence of the description.

elem-shortCode.xml: replaced 'MARC Code List' by 'MARC Field Index to Source Code' in the description section.

elem-sources.xml and elem-source.xml: fixed the @xml:lang attribute of the example.

elem-span.xml: changed a word in the attribute usage section.

elem-title.xml: typo.

attr-relationType.xml : fixed the value of @relationType in the eaf example

attr-relationTypeEncoding: fixed the description so that it is consistent with that of @relationType.

attr-sourceReference: modified the description to make it clearer.

attr-target.xml: Fixed the values of @target attributes in the examples.

attr-targetType.xml: Fixed the value of the @xml:lang attr for the first example

attr-valueURI.xml: Fixed the value of @xml:lang for 2 examples

attr-vocabularySource.xml: Small change in the description, plus fixing the values of 2 @xml:lang

attr-vocabularySourceURI.xml : Fixed the values of 2 @xml:lang