### PR TITLE
HTML: swapping label and title

### DIFF
--- a/html/EAC-CPF3-TL-eng.html
+++ b/html/EAC-CPF3-TL-eng.html
@@ -976,7 +976,7 @@
                         the third major revision of the standard EAC-CPF. It supersedes the standard
                         version EAC-CPF 2.0.1 (2024).</div>
                   <div class="p">The release reflects the commitment to align all EAS where possible and
-                        practica.</div>
+                        practical.</div>
                   <div class="p">The EAC-CPF Tag Library is a living document. As such, it will continue to be
                         developed as users suggest areas in need of clarification or expansion. The
                         TS-EAS still encourages implementers to provide any queries, comments, and
@@ -1090,11 +1090,10 @@
             <div class="section" id="d1e165">
                <div class="head03">Elements</div>
                <div class="element">
-                  <div class="leftcol" id="elem-abstract">
+                  <div class="leftcol">
+                     <span class="label">Abstract</span>  </div>
+                  <div class="content" id="elem-abstract">
                      <span class="label">&lt;abstract&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Abstract</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1212,11 +1211,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-address">
+                  <div class="leftcol">
+                     <span class="label">Address</span>  </div>
+                  <div class="content" id="elem-address">
                      <span class="label">&lt;address&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1325,11 +1323,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-addressLine">
+                  <div class="leftcol">
+                     <span class="label">Address Line</span>  </div>
+                  <div class="content" id="elem-addressLine">
                      <span class="label">&lt;addressLine&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address Line</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1434,11 +1431,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agencyCode">
+                  <div class="leftcol">
+                     <span class="label">Agency Code</span>  </div>
+                  <div class="content" id="elem-agencyCode">
                      <span class="label">&lt;agencyCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agency Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1545,11 +1541,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agencyName">
+                  <div class="leftcol">
+                     <span class="label">Agency Name</span>  </div>
+                  <div class="content" id="elem-agencyName">
                      <span class="label">&lt;agencyName&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agency Name</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1644,11 +1639,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agent">
+                  <div class="leftcol">
+                     <span class="label">Agent</span>  </div>
+                  <div class="content" id="elem-agent">
                      <span class="label">&lt;agent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1810,11 +1804,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-alternativeSet">
+                  <div class="leftcol">
+                     <span class="label">Alternative Set</span>  </div>
+                  <div class="content" id="elem-alternativeSet">
                      <span class="label">&lt;alternativeSet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Alternative Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1920,11 +1913,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-biogHist">
+                  <div class="leftcol">
+                     <span class="label">Biography or History</span>  </div>
+                  <div class="content" id="elem-biogHist">
                      <span class="label">&lt;biogHist&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Biography or History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2052,11 +2044,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-citedRange">
+                  <div class="leftcol">
+                     <span class="label">Cited Range</span>  </div>
+                  <div class="content" id="elem-citedRange">
                      <span class="label">&lt;citedRange&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Cited Range</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2156,11 +2147,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-componentEntry">
+                  <div class="leftcol">
+                     <span class="label">Component Entry</span>  </div>
+                  <div class="content" id="elem-componentEntry">
                      <span class="label">&lt;componentEntry&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component Entry</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2285,11 +2275,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-contact">
+                  <div class="leftcol">
+                     <span class="label">Contact</span>  </div>
+                  <div class="content" id="elem-contact">
                      <span class="label">&lt;contact&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2394,11 +2383,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-contactLine">
+                  <div class="leftcol">
+                     <span class="label">Contact Line</span>  </div>
+                  <div class="content" id="elem-contactLine">
                      <span class="label">&lt;contactLine&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact Line</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2519,11 +2507,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-control">
+                  <div class="leftcol">
+                     <span class="label">Control</span>  </div>
+                  <div class="content" id="elem-control">
                      <span class="label">&lt;control&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Control</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2803,11 +2790,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-conventionDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Convention Declaration</span>  </div>
+                  <div class="content" id="elem-conventionDeclaration">
                      <span class="label">&lt;conventionDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Convention Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2922,11 +2908,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-cpfDescription">
+                  <div class="leftcol">
+                     <span class="label">CPF Description</span>  </div>
+                  <div class="content" id="elem-cpfDescription">
                      <span class="label">&lt;cpfDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">CPF Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3060,11 +3045,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-date">
+                  <div class="leftcol">
+                     <span class="label">Date</span>  </div>
+                  <div class="content" id="elem-date">
                      <span class="label">&lt;date&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3230,11 +3214,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dateRange">
+                  <div class="leftcol">
+                     <span class="label">Date Range</span>  </div>
+                  <div class="content" id="elem-dateRange">
                      <span class="label">&lt;dateRange&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Range</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3364,11 +3347,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dateSet">
+                  <div class="leftcol">
+                     <span class="label">Date Set</span>  </div>
+                  <div class="content" id="elem-dateSet">
                      <span class="label">&lt;dateSet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3468,11 +3450,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-demographicDescription">
+                  <div class="leftcol">
+                     <span class="label">Demographic Description</span>  </div>
+                  <div class="content" id="elem-demographicDescription">
                      <span class="label">&lt;demographicDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Demographic Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3631,11 +3612,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-demographicDescriptions">
+                  <div class="leftcol">
+                     <span class="label">Demographic Descriptions</span>  </div>
+                  <div class="content" id="elem-demographicDescriptions">
                      <span class="label">&lt;demographicDescriptions&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Demographic Descriptions</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3750,11 +3730,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-description">
+                  <div class="leftcol">
+                     <span class="label">Description</span>  </div>
+                  <div class="content" id="elem-description">
                      <span class="label">&lt;description&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3925,11 +3904,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-descriptiveNote">
+                  <div class="leftcol">
+                     <span class="label">Descriptive Note</span>  </div>
+                  <div class="content" id="elem-descriptiveNote">
                      <span class="label">&lt;descriptiveNote&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Descriptive Note</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4025,11 +4003,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eac">
+                  <div class="leftcol">
+                     <span class="label">Encoded Archival Context - Corporate Bodies, Persons, and Families</span>  </div>
+                  <div class="content" id="elem-eac">
                      <span class="label">&lt;eac&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Encoded Archival Context - Corporate Bodies, Persons, and Families</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4102,11 +4079,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-entityType">
+                  <div class="leftcol">
+                     <span class="label">Entity Type</span>  </div>
+                  <div class="content" id="elem-entityType">
                      <span class="label">&lt;entityType&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Entity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4189,11 +4165,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eventDateTime">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Date and Time</span>  </div>
+                  <div class="content" id="elem-eventDateTime">
                      <span class="label">&lt;eventDateTime&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Date and Time</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4276,11 +4251,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eventDescription">
+                  <div class="leftcol">
+                     <span class="label">Event Description</span>  </div>
+                  <div class="content" id="elem-eventDescription">
                      <span class="label">&lt;eventDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Event Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4384,11 +4358,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-existDates">
+                  <div class="leftcol">
+                     <span class="label">Dates of Existence</span>  </div>
+                  <div class="content" id="elem-existDates">
                      <span class="label">&lt;existDates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Dates of Existence</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4518,11 +4491,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-formattingExtension">
+                  <div class="leftcol">
+                     <span class="label">Formatting Extension</span>  </div>
+                  <div class="content" id="elem-formattingExtension">
                      <span class="label">&lt;formattingExtension&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Formatting Extension</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4579,11 +4551,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-fromDate">
+                  <div class="leftcol">
+                     <span class="label">From Date</span>  </div>
+                  <div class="content" id="elem-fromDate">
                      <span class="label">&lt;fromDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">From Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4763,11 +4734,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionPerformed">
+                  <div class="leftcol">
+                     <span class="label">Function Performed</span>  </div>
+                  <div class="content" id="elem-functionPerformed">
                      <span class="label">&lt;functionPerformed&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Performed</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4931,11 +4901,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionsPerformed">
+                  <div class="leftcol">
+                     <span class="label">Functions Performed</span>  </div>
+                  <div class="content" id="elem-functionsPerformed">
                      <span class="label">&lt;functionsPerformed&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Functions Performed</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5049,11 +5018,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-generalContext">
+                  <div class="leftcol">
+                     <span class="label">General Context</span>  </div>
+                  <div class="content" id="elem-generalContext">
                      <span class="label">&lt;generalContext&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">General Context</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5167,11 +5135,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-geographicCoordinates">
+                  <div class="leftcol">
+                     <span class="label">Geographic Coordinates</span>  </div>
+                  <div class="content" id="elem-geographicCoordinates">
                      <span class="label">&lt;geographicCoordinates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Geographic Coordinates</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5272,11 +5239,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-identity">
+                  <div class="leftcol">
+                     <span class="label">Identity</span>  </div>
+                  <div class="content" id="elem-identity">
                      <span class="label">&lt;identity&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5429,11 +5395,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-identityId">
+                  <div class="leftcol">
+                     <span class="label">Identity Identifier</span>  </div>
+                  <div class="content" id="elem-identityId">
                      <span class="label">&lt;identityId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5555,11 +5520,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-label">
+                  <div class="leftcol">
+                     <span class="label">Label</span>  </div>
+                  <div class="content" id="elem-label">
                      <span class="label">&lt;label&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Label</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5689,11 +5653,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-language">
+                  <div class="leftcol">
+                     <span class="label">Language</span>  </div>
+                  <div class="content" id="elem-language">
                      <span class="label">&lt;language&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5799,11 +5762,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languageDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Language Declaration</span>  </div>
+                  <div class="content" id="elem-languageDeclaration">
                      <span class="label">&lt;languageDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5899,11 +5861,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languageUsed">
+                  <div class="leftcol">
+                     <span class="label">Language Used</span>  </div>
+                  <div class="content" id="elem-languageUsed">
                      <span class="label">&lt;languageUsed&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Used</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6030,11 +5991,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languagesUsed">
+                  <div class="leftcol">
+                     <span class="label">Languages Used</span>  </div>
+                  <div class="content" id="elem-languagesUsed">
                      <span class="label">&lt;languagesUsed&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Languages Used</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6148,11 +6108,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-legalStatus">
+                  <div class="leftcol">
+                     <span class="label">Legal Status</span>  </div>
+                  <div class="content" id="elem-legalStatus">
                      <span class="label">&lt;legalStatus&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Legal Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6299,11 +6258,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-legalStatuses">
+                  <div class="leftcol">
+                     <span class="label">Legal Statuses</span>  </div>
+                  <div class="content" id="elem-legalStatuses">
                      <span class="label">&lt;legalStatuses&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Legal Statuses</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6417,11 +6375,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-localDescription">
+                  <div class="leftcol">
+                     <span class="label">Local Description</span>  </div>
+                  <div class="content" id="elem-localDescription">
                      <span class="label">&lt;localDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6576,11 +6533,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-localDescriptions">
+                  <div class="leftcol">
+                     <span class="label">Local Descriptions</span>  </div>
+                  <div class="content" id="elem-localDescriptions">
                      <span class="label">&lt;localDescriptions&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Descriptions</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6694,11 +6650,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-localTypeDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Local Type Declaration</span>  </div>
+                  <div class="content" id="elem-localTypeDeclaration">
                      <span class="label">&lt;localTypeDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6812,11 +6767,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceAgency">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Agency</span>  </div>
+                  <div class="content" id="elem-maintenanceAgency">
                      <span class="label">&lt;maintenanceAgency&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Agency</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6955,11 +6909,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceEvent">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event</span>  </div>
+                  <div class="content" id="elem-maintenanceEvent">
                      <span class="label">&lt;maintenanceEvent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7063,11 +7016,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceHistory">
+                  <div class="leftcol">
+                     <span class="label">Maintenance History</span>  </div>
+                  <div class="content" id="elem-maintenanceHistory">
                      <span class="label">&lt;maintenanceHistory&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7142,11 +7094,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-mandate">
+                  <div class="leftcol">
+                     <span class="label">Mandate</span>  </div>
+                  <div class="content" id="elem-mandate">
                      <span class="label">&lt;mandate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Mandate</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7304,11 +7255,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-mandates">
+                  <div class="leftcol">
+                     <span class="label">Mandates</span>  </div>
+                  <div class="content" id="elem-mandates">
                      <span class="label">&lt;mandates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Mandates</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7422,11 +7372,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-multipleIdentities">
+                  <div class="leftcol">
+                     <span class="label">Multiple Identities</span>  </div>
+                  <div class="content" id="elem-multipleIdentities">
                      <span class="label">&lt;multipleIdentities&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Multiple Identities</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7494,11 +7443,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-nameEntry">
+                  <div class="leftcol">
+                     <span class="label">Name Entry</span>  </div>
+                  <div class="content" id="elem-nameEntry">
                      <span class="label">&lt;nameEntry&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Name Entry</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7670,11 +7618,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-nameEntrySet">
+                  <div class="leftcol">
+                     <span class="label">Name Entry Set</span>  </div>
+                  <div class="content" id="elem-nameEntrySet">
                      <span class="label">&lt;nameEntrySet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Name Entry Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7793,11 +7740,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-narrativeEvent">
+                  <div class="leftcol">
+                     <span class="label">Narrative Event</span>  </div>
+                  <div class="content" id="elem-narrativeEvent">
                      <span class="label">&lt;narrativeEvent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Narrative Event</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7923,11 +7869,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-objectXMLWrap">
+                  <div class="leftcol">
+                     <span class="label">Object XML Wrap</span>  </div>
+                  <div class="content" id="elem-objectXMLWrap">
                      <span class="label">&lt;objectXMLWrap&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Object XML Wrap</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7985,11 +7930,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-narrativeEvent">
+                  <div class="leftcol">
+                     <span class="label">Narrative Event</span>  </div>
+                  <div class="content" id="elem-narrativeEvent">
                      <span class="label">&lt;narrativeEvent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Narrative Event</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8115,11 +8059,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-occupation">
+                  <div class="leftcol">
+                     <span class="label">Occupation</span>  </div>
+                  <div class="content" id="elem-occupation">
                      <span class="label">&lt;occupation&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Occupation</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8274,11 +8217,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-occupations">
+                  <div class="leftcol">
+                     <span class="label">Occupations</span>  </div>
+                  <div class="content" id="elem-occupations">
                      <span class="label">&lt;occupations&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Occupations</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8392,11 +8334,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherAgencyCode">
+                  <div class="leftcol">
+                     <span class="label">Other Agency Code</span>  </div>
+                  <div class="content" id="elem-otherAgencyCode">
                      <span class="label">&lt;otherAgencyCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Agency Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8514,11 +8455,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherEntityType">
+                  <div class="leftcol">
+                     <span class="label">Other Entity Type</span>  </div>
+                  <div class="content" id="elem-otherEntityType">
                      <span class="label">&lt;otherEntityType&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Entity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8674,11 +8614,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherEntityTypes">
+                  <div class="leftcol">
+                     <span class="label">Other Entity Types</span>  </div>
+                  <div class="content" id="elem-otherEntityTypes">
                      <span class="label">&lt;otherEntityTypes&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Entity Types</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8786,11 +8725,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherRecordId">
+                  <div class="leftcol">
+                     <span class="label">Other Record Identifier</span>  </div>
+                  <div class="content" id="elem-otherRecordId">
                      <span class="label">&lt;otherRecordId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Record Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8899,11 +8837,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-p">
+                  <div class="leftcol">
+                     <span class="label">Paragraph</span>  </div>
+                  <div class="content" id="elem-p">
                      <span class="label">&lt;p&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Paragraph</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9009,11 +8946,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-part">
+                  <div class="leftcol">
+                     <span class="label">Part</span>  </div>
+                  <div class="content" id="elem-part">
                      <span class="label">&lt;part&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Part</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9121,11 +9057,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-place">
+                  <div class="leftcol">
+                     <span class="label">Place</span>  </div>
+                  <div class="content" id="elem-place">
                      <span class="label">&lt;place&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9292,11 +9227,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-placeName">
+                  <div class="leftcol">
+                     <span class="label">Place Name</span>  </div>
+                  <div class="content" id="elem-placeName">
                      <span class="label">&lt;placeName&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Name</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9432,11 +9366,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-places">
+                  <div class="leftcol">
+                     <span class="label">Places</span>  </div>
+                  <div class="content" id="elem-places">
                      <span class="label">&lt;places&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Places</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9547,11 +9480,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-recordId">
+                  <div class="leftcol">
+                     <span class="label">Record Identifier</span>  </div>
+                  <div class="content" id="elem-recordId">
                      <span class="label">&lt;recordId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Record Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9628,11 +9560,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-reference">
+                  <div class="leftcol">
+                     <span class="label">Reference</span>  </div>
+                  <div class="content" id="elem-reference">
                      <span class="label">&lt;reference&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9778,11 +9709,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relation">
+                  <div class="leftcol">
+                     <span class="label">Relation</span>  </div>
+                  <div class="content" id="elem-relation">
                      <span class="label">&lt;relation&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9927,11 +9857,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relations">
+                  <div class="leftcol">
+                     <span class="label">Relations</span>  </div>
+                  <div class="content" id="elem-relations">
                      <span class="label">&lt;relations&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relations</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10030,11 +9959,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relationship">
+                  <div class="leftcol">
+                     <span class="label">Relationship</span>  </div>
+                  <div class="content" id="elem-relationship">
                      <span class="label">&lt;relationship&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relationship</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10163,11 +10091,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-referringString">
+                  <div class="leftcol">
+                     <span class="label">Referring String</span>  </div>
+                  <div class="content" id="elem-referringString">
                      <span class="label">&lt;referringString&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referring String</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10316,11 +10243,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-rightsDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Rights Declaration</span>  </div>
+                  <div class="content" id="elem-rightsDeclaration">
                      <span class="label">&lt;rightsDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Rights Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10432,11 +10358,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-role">
+                  <div class="leftcol">
+                     <span class="label">Role</span>  </div>
+                  <div class="content" id="elem-role">
                      <span class="label">&lt;role&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Role</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10547,11 +10472,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-setComponent">
+                  <div class="leftcol">
+                     <span class="label">Set Component</span>  </div>
+                  <div class="content" id="elem-setComponent">
                      <span class="label">&lt;setComponent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Set Component</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10691,11 +10615,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-shortCode">
+                  <div class="leftcol">
+                     <span class="label">Short Code</span>  </div>
+                  <div class="content" id="elem-shortCode">
                      <span class="label">&lt;shortCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Short Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10764,11 +10687,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-source">
+                  <div class="leftcol">
+                     <span class="label">Source</span>  </div>
+                  <div class="content" id="elem-source">
                      <span class="label">&lt;source&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10909,11 +10831,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-sources">
+                  <div class="leftcol">
+                     <span class="label">Sources</span>  </div>
+                  <div class="content" id="elem-sources">
                      <span class="label">&lt;sources&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Sources</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10994,11 +10915,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-span">
+                  <div class="leftcol">
+                     <span class="label">span</span>  </div>
+                  <div class="content" id="elem-span">
                      <span class="label">&lt;span&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">span</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11111,11 +11031,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-structureOrGenealogy">
+                  <div class="leftcol">
+                     <span class="label">Structure or Genealogy</span>  </div>
+                  <div class="content" id="elem-structureOrGenealogy">
                      <span class="label">&lt;structureOrGenealogy&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Structure or Genealogy</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11225,11 +11144,10 @@ described. A simpler discursive expression of the structure(s)
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-term">
+                  <div class="leftcol">
+                     <span class="label">Term</span>  </div>
+                  <div class="content" id="elem-term">
                      <span class="label">&lt;term&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Term</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11318,11 +11236,10 @@ described. A simpler discursive expression of the structure(s)
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-toDate">
+                  <div class="leftcol">
+                     <span class="label">To Date</span>  </div>
+                  <div class="content" id="elem-toDate">
                      <span class="label">&lt;toDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">To Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11482,11 +11399,10 @@ described. A simpler discursive expression of the structure(s)
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-useDates">
+                  <div class="leftcol">
+                     <span class="label">Dates of Use</span>  </div>
+                  <div class="content" id="elem-useDates">
                      <span class="label">&lt;useDates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Dates of Use</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11576,11 +11492,10 @@ described. A simpler discursive expression of the structure(s)
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-writingSystem">
+                  <div class="leftcol">
+                     <span class="label">Writing System</span>  </div>
+                  <div class="content" id="elem-writingSystem">
                      <span class="label">&lt;writingSystem&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Writing System</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11753,11 +11668,10 @@ described. A simpler discursive expression of the structure(s)
                         information about the use of certain attributes may be found in the
                         "Attribute usage" section of the element descriptions.</div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-addressLineType">
+                  <div class="leftcol">
+                     <span class="label">Address Line Type</span>  </div>
+                  <div class="content" id="attr-addressLineType">
                      <span class="label">@addressLineType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address Line Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11779,11 +11693,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-addressLineTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Address Line Type Encoding</span>  </div>
+                  <div class="content" id="attr-addressLineTypeEncoding">
                      <span class="label">@addressLineTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address Line Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11805,11 +11718,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-agentType">
+                  <div class="leftcol">
+                     <span class="label">Agent Type</span>  </div>
+                  <div class="content" id="attr-agentType">
                      <span class="label">@agentType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11831,11 +11743,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-agentTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Agent Type Encoding</span>  </div>
+                  <div class="content" id="attr-agentTypeEncoding">
                      <span class="label">@agentTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11857,11 +11768,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-audience">
+                  <div class="leftcol">
+                     <span class="label">Audience</span>  </div>
+                  <div class="content" id="attr-audience">
                      <span class="label">@audience</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Audience</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11883,11 +11793,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-audienceEncoding">
+                  <div class="leftcol">
+                     <span class="label">Audience Encoding</span>  </div>
+                  <div class="content" id="attr-audienceEncoding">
                      <span class="label">@audienceEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Audience Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11909,11 +11818,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-calendar">
+                  <div class="leftcol">
+                     <span class="label">Calendar</span>  </div>
+                  <div class="content" id="attr-calendar">
                      <span class="label">@calendar</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Calendar</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11937,11 +11845,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-certainty">
+                  <div class="leftcol">
+                     <span class="label">Certainty</span>  </div>
+                  <div class="content" id="attr-certainty">
                      <span class="label">@certainty</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Certainty</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11965,11 +11872,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-contactLineType">
+                  <div class="leftcol">
+                     <span class="label">Contact Line Type</span>  </div>
+                  <div class="content" id="attr-contactLineType">
                      <span class="label">@contactLineType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact Line Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11989,11 +11895,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-contactLineTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Contact Line Type Encoding</span>  </div>
+                  <div class="content" id="attr-contactLineTypeEncoding">
                      <span class="label">@contactLineTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact Line Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12015,11 +11920,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-conventionDeclarationReference">
+                  <div class="leftcol">
+                     <span class="label">Convention Declaration Reference</span>  </div>
+                  <div class="content" id="attr-conventionDeclarationReference">
                      <span class="label">@conventionDeclarationReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Convention Declaration Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12047,11 +11951,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-coordinateSystem">
+                  <div class="leftcol">
+                     <span class="label">Coordinate System</span>  </div>
+                  <div class="content" id="attr-coordinateSystem">
                      <span class="label">@coordinateSystem</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Coordinate System</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12074,11 +11977,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-countryCode">
+                  <div class="leftcol">
+                     <span class="label">Country Code</span>  </div>
+                  <div class="content" id="attr-countryCode">
                      <span class="label">@countryCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Country Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12097,11 +11999,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-countryEncoding">
+                  <div class="leftcol">
+                     <span class="label">Country Encoding</span>  </div>
+                  <div class="content" id="attr-countryEncoding">
                      <span class="label">@countryEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Country Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12124,11 +12025,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-dateEncoding">
+                  <div class="leftcol">
+                     <span class="label">Date Encoding</span>  </div>
+                  <div class="content" id="attr-dateEncoding">
                      <span class="label">@dateEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12151,11 +12051,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-detailLevel">
+                  <div class="leftcol">
+                     <span class="label">Level of Detail</span>  </div>
+                  <div class="content" id="attr-detailLevel">
                      <span class="label">@detailLevel</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Level of Detail</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12175,11 +12074,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-detailLevelEncoding">
+                  <div class="leftcol">
+                     <span class="label">Detail Level Encoding</span>  </div>
+                  <div class="content" id="attr-detailLevelEncoding">
                      <span class="label">@detailLevelEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Detail Level Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12201,11 +12099,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-era">
+                  <div class="leftcol">
+                     <span class="label">Era</span>  </div>
+                  <div class="content" id="attr-era">
                      <span class="label">@era</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Era</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12228,11 +12125,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-href">
+                  <div class="leftcol">
+                     <span class="label">Hypertext Reference</span>  </div>
+                  <div class="content" id="attr-href">
                      <span class="label">@href</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Hypertext Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12255,11 +12151,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-id">
+                  <div class="leftcol">
+                     <span class="label">ID</span>  </div>
+                  <div class="content" id="attr-id">
                      <span class="label">@id</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">ID</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12283,11 +12178,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-identityType">
+                  <div class="leftcol">
+                     <span class="label">Identity Type</span>  </div>
+                  <div class="content" id="attr-identityType">
                      <span class="label">@identityType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12306,11 +12200,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-identityTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Identity Type Encoding</span>  </div>
+                  <div class="content" id="attr-identityTypeEncoding">
                      <span class="label">@identityTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12332,11 +12225,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageCode">
+                  <div class="leftcol">
+                     <span class="label">Language Code</span>  </div>
+                  <div class="content" id="attr-languageCode">
                      <span class="label">@languageCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12357,11 +12249,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageEncoding">
+                  <div class="leftcol">
+                     <span class="label">Language Encoding</span>  </div>
+                  <div class="content" id="attr-languageEncoding">
                      <span class="label">@languageEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12384,11 +12275,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageOfElement">
+                  <div class="leftcol">
+                     <span class="label">Language of Element</span>  </div>
+                  <div class="content" id="attr-languageOfElement">
                      <span class="label">@languageOfElement</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language of Element</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12410,11 +12300,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-linkRole">
+                  <div class="leftcol">
+                     <span class="label">Link Role</span>  </div>
+                  <div class="content" id="attr-linkRole">
                      <span class="label">@linkRole</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Link Role</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12437,11 +12326,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-linkTitle">
+                  <div class="leftcol">
+                     <span class="label">Link Title</span>  </div>
+                  <div class="content" id="attr-linkTitle">
                      <span class="label">@linkTitle</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Link Title</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12467,11 +12355,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-localType">
+                  <div class="leftcol">
+                     <span class="label">Local Type</span>  </div>
+                  <div class="content" id="attr-localType">
                      <span class="label">@localType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12504,11 +12391,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-localTypeDeclarationReference">
+                  <div class="leftcol">
+                     <span class="label">Local Type Declaration Reference</span>  </div>
+                  <div class="content" id="attr-localTypeDeclarationReference">
                      <span class="label">@localTypeDeclarationReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type Declaration Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12535,11 +12421,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventReference">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Reference</span>  </div>
+                  <div class="content" id="attr-maintenanceEventReference">
                      <span class="label">@maintenanceEventReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12560,11 +12445,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventType">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Type</span>  </div>
+                  <div class="content" id="attr-maintenanceEventType">
                      <span class="label">@maintenanceEventType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12586,11 +12470,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Type Encoding</span>  </div>
+                  <div class="content" id="attr-maintenanceEventTypeEncoding">
                      <span class="label">@maintenanceEventTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12612,11 +12495,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceStatus">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Status</span>  </div>
+                  <div class="content" id="attr-maintenanceStatus">
                      <span class="label">@maintenanceStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12635,11 +12517,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Status Encoding</span>  </div>
+                  <div class="content" id="attr-maintenanceStatusEncoding">
                      <span class="label">@maintenanceStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12661,11 +12542,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-normalizedForm">
+                  <div class="leftcol">
+                     <span class="label">Normalized Form</span>  </div>
+                  <div class="content" id="attr-normalizedForm">
                      <span class="label">@normalizedForm</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Normalized Form</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12684,11 +12564,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-notAfter">
+                  <div class="leftcol">
+                     <span class="label">Not After</span>  </div>
+                  <div class="content" id="attr-notAfter">
                      <span class="label">@notAfter</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Not After</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12709,11 +12588,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-notBefore">
+                  <div class="leftcol">
+                     <span class="label">Not Before</span>  </div>
+                  <div class="content" id="attr-notBefore">
                      <span class="label">@notBefore</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Not Before</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12734,11 +12612,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-placeType">
+                  <div class="leftcol">
+                     <span class="label">Place Type</span>  </div>
+                  <div class="content" id="attr-placeType">
                      <span class="label">@placeType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12760,11 +12637,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-placeTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Place Type Encoding</span>  </div>
+                  <div class="content" id="attr-placeTypeEncoding">
                      <span class="label">@placeTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12786,11 +12662,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-preferredForm">
+                  <div class="leftcol">
+                     <span class="label">Preferred Form</span>  </div>
+                  <div class="content" id="attr-preferredForm">
                      <span class="label">@preferredForm</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Preferred Form</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12814,11 +12689,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-publicationStatus">
+                  <div class="leftcol">
+                     <span class="label">Publication Status</span>  </div>
+                  <div class="content" id="attr-publicationStatus">
                      <span class="label">@publicationStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12840,11 +12714,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-publicationStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Publication Status Encoding</span>  </div>
+                  <div class="content" id="attr-publicationStatusEncoding">
                      <span class="label">@publicationStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12866,11 +12739,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityRelationship">
+                  <div class="leftcol">
+                     <span class="label">Referred Entity Relationship</span>  </div>
+                  <div class="content" id="attr-referredEntityRelationship">
                      <span class="label">@referredEntityRelationship</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referred Entity Relationship</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12888,11 +12760,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityType">
+                  <div class="leftcol">
+                     <span class="label">Referrered Entity Type</span>  </div>
+                  <div class="content" id="attr-referredEntityType">
                      <span class="label">@referredEntityType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referrered Entity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12914,11 +12785,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Referred Entity Type Encoding</span>  </div>
+                  <div class="content" id="attr-referredEntityTypeEncoding">
                      <span class="label">@referredEntityTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referred Entity Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12940,11 +12810,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-relationType">
+                  <div class="leftcol">
+                     <span class="label">Relation Type</span>  </div>
+                  <div class="content" id="attr-relationType">
                      <span class="label">@relationType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12966,11 +12835,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-relationTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Relation Type Encoding</span>  </div>
+                  <div class="content" id="attr-relationTypeEncoding">
                      <span class="label">@relationTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12992,11 +12860,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-repositoryEncoding">
+                  <div class="leftcol">
+                     <span class="label">Repository Encoding</span>  </div>
+                  <div class="content" id="attr-repositoryEncoding">
                      <span class="label">@repositoryEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Repository Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13019,11 +12886,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptCode">
+                  <div class="leftcol">
+                     <span class="label">Script Code</span>  </div>
+                  <div class="content" id="attr-scriptCode">
                      <span class="label">@scriptCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13044,11 +12910,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptEncoding">
+                  <div class="leftcol">
+                     <span class="label">Script Encoding</span>  </div>
+                  <div class="content" id="attr-scriptEncoding">
                      <span class="label">@scriptEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13070,11 +12935,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptOfElement">
+                  <div class="leftcol">
+                     <span class="label">Script of Element</span>  </div>
+                  <div class="content" id="attr-scriptOfElement">
                      <span class="label">@scriptOfElement</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script of Element</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13095,11 +12959,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-sourceReference">
+                  <div class="leftcol">
+                     <span class="label">Source Reference</span>  </div>
+                  <div class="content" id="attr-sourceReference">
                      <span class="label">@sourceReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13122,11 +12985,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-standardDate">
+                  <div class="leftcol">
+                     <span class="label">Standard Date</span>  </div>
+                  <div class="content" id="attr-standardDate">
                      <span class="label">@standardDate</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Standard Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13147,11 +13009,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-standardDateTime">
+                  <div class="leftcol">
+                     <span class="label">Standard Date and Time</span>  </div>
+                  <div class="content" id="attr-standardDateTime">
                      <span class="label">@standardDateTime</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Standard Date and Time</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13179,11 +13040,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-status">
+                  <div class="leftcol">
+                     <span class="label">Status</span>  </div>
+                  <div class="content" id="attr-status">
                      <span class="label">@status</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13206,11 +13066,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-statusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Status Encoding</span>  </div>
+                  <div class="content" id="attr-statusEncoding">
                      <span class="label">@statusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13236,11 +13095,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-style">
+                  <div class="leftcol">
+                     <span class="label">Style</span>  </div>
+                  <div class="content" id="attr-style">
                      <span class="label">@style</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Style</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13261,11 +13119,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-target">
+                  <div class="leftcol">
+                     <span class="label">Target</span>  </div>
+                  <div class="content" id="attr-target">
                      <span class="label">@target</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13286,11 +13143,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-targetType">
+                  <div class="leftcol">
+                     <span class="label">Target Type</span>  </div>
+                  <div class="content" id="attr-targetType">
                      <span class="label">@targetType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13313,11 +13169,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-targetTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Target Type Encoding</span>  </div>
+                  <div class="content" id="attr-targetTypeEncoding">
                      <span class="label">@targetTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13339,11 +13194,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-unit">
+                  <div class="leftcol">
+                     <span class="label">Unit</span>  </div>
+                  <div class="content" id="attr-unit">
                      <span class="label">@unit</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Unit</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13364,11 +13218,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-value">
+                  <div class="leftcol">
+                     <span class="label">Value</span>  </div>
+                  <div class="content" id="attr-value">
                      <span class="label">@value</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Value</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13389,11 +13242,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-valueURI">
+                  <div class="leftcol">
+                     <span class="label">Value URI</span>  </div>
+                  <div class="content" id="attr-valueURI">
                      <span class="label">@valueURI</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Value URI</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13415,11 +13267,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-vocabularySource">
+                  <div class="leftcol">
+                     <span class="label">Vocabulary Source</span>  </div>
+                  <div class="content" id="attr-vocabularySource">
                      <span class="label">@vocabularySource</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Vocabulary Source</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13440,11 +13291,10 @@ described. A simpler discursive expression of the structure(s)
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-vocabularySourceURI">
+                  <div class="leftcol">
+                     <span class="label">Vocabulary Source URI</span>  </div>
+                  <div class="content" id="attr-vocabularySourceURI">
                      <span class="label">@vocabularySourceURI</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Vocabulary Source URI</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">

--- a/html/EAC-CPF3-TL-eng.html
+++ b/html/EAC-CPF3-TL-eng.html
@@ -2379,8 +2379,6 @@
                   <div class="content">
                      <div class="p">Optional, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -2503,8 +2501,6 @@
                   <div class="content">
                      <div class="p">Required, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -3446,8 +3442,6 @@
                      <div class="p">Within <a href="#elem-agent">&lt;agent&gt;</a>, <a href="#elem-demographicDescription">&lt;demographicDescription&gt;</a>, <a href="#elem-functionPerformed">&lt;functionPerformed&gt;</a>, <a href="#elem-legalStatus">&lt;legalStatus&gt;</a>, <a href="#elem-localDescription">&lt;localDescription&gt;</a>, <a href="#elem-mandate">&lt;mandate&gt;</a>, <a href="#elem-occupation">&lt;occupation&gt;</a>, <a href="#elem-otherEntityType">&lt;otherEntityType&gt;</a>, <a href="#elem-place">&lt;place&gt;</a>, <a href="#elem-relation">&lt;relation&gt;</a>: one of <a href="#elem-date">&lt;date&gt;</a>, <a href="#elem-dateRange">&lt;dateRange&gt;</a>, or <a href="#elem-dateSet">&lt;dateSet&gt;</a> optional, not repeatable</div>
                      <div class="p">Within <a href="#elem-existDates">&lt;existDates&gt;</a>, <a href="#elem-useDates">&lt;useDates&gt;</a>: one of <a href="#elem-date">&lt;date&gt;</a>, <a href="#elem-dateRange">&lt;dateRange&gt;</a>, or <a href="#elem-dateSet">&lt;dateSet&gt;</a> required, not repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -4547,8 +4541,6 @@
                      <div class="p">Optional, not repeatable</div>
                      <div class="p">In these narrative contexts, the encoder must choose between using a <a href="#elem-formattingExtention">&lt;formattingExtention&gt;</a> element (to wrap XHTML content), or using one or more <a href="#elem-p">&lt;p&gt;</a> elements that are defined within the current EAS schema.</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -7926,8 +7918,6 @@
                   <div class="content">
                      <div class="p">Optional, not repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -11890,8 +11880,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -11994,8 +11982,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -12069,8 +12055,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -12321,8 +12305,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">anyURI</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -12440,8 +12422,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">IDREFS</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -12559,8 +12539,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -12980,8 +12958,6 @@ described. A simpler discursive expression of the structure(s)
                   <div class="content">
                      <div class="p">IDREFS</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">

--- a/html/EAD4-TL-eng.html
+++ b/html/EAD4-TL-eng.html
@@ -1130,11 +1130,10 @@
             <div class="section" id="d1e96">
                <div class="head03">Elements</div>
                <div class="element">
-                  <div class="leftcol" id="elem-abstract">
+                  <div class="leftcol">
+                     <span class="label">Abstract</span>  </div>
+                  <div class="content" id="elem-abstract">
                      <span class="label">&lt;abstract&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Abstract</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1252,11 +1251,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-accessConditions">
+                  <div class="leftcol">
+                     <span class="label">Access Conditions</span>  </div>
+                  <div class="content" id="elem-accessConditions">
                      <span class="label">&lt;accessConditions&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Access Conditions</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1414,11 +1412,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-accruals">
+                  <div class="leftcol">
+                     <span class="label">Accruals</span>  </div>
+                  <div class="content" id="elem-accruals">
                      <span class="label">&lt;accruals&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Accruals</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1541,11 +1538,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-address">
+                  <div class="leftcol">
+                     <span class="label">Address</span>  </div>
+                  <div class="content" id="elem-address">
                      <span class="label">&lt;address&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1654,11 +1650,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-addressLine">
+                  <div class="leftcol">
+                     <span class="label">Address Line</span>  </div>
+                  <div class="content" id="elem-addressLine">
                      <span class="label">&lt;addressLine&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address Line</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1763,11 +1758,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agencyCode">
+                  <div class="leftcol">
+                     <span class="label">Agency Code</span>  </div>
+                  <div class="content" id="elem-agencyCode">
                      <span class="label">&lt;agencyCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agency Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1874,11 +1868,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agencyName">
+                  <div class="leftcol">
+                     <span class="label">Agency Name</span>  </div>
+                  <div class="content" id="elem-agencyName">
                      <span class="label">&lt;agencyName&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agency Name</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1973,11 +1966,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agent">
+                  <div class="leftcol">
+                     <span class="label">Agent</span>  </div>
+                  <div class="content" id="elem-agent">
                      <span class="label">&lt;agent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2142,11 +2134,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agents">
+                  <div class="leftcol">
+                     <span class="label">Agents</span>  </div>
+                  <div class="content" id="elem-agents">
                      <span class="label">&lt;agents&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agents</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2257,11 +2248,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-appraisal">
+                  <div class="leftcol">
+                     <span class="label">Appraisal Information</span>  </div>
+                  <div class="content" id="elem-appraisal">
                      <span class="label">&lt;appraisal&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Appraisal Information</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2386,11 +2376,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-archDesc">
+                  <div class="leftcol">
+                     <span class="label">Archival Description</span>  </div>
+                  <div class="content" id="elem-archDesc">
                      <span class="label">&lt;archDesc&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Archival Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2659,11 +2648,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-arrangement">
+                  <div class="leftcol">
+                     <span class="label">Arrangement</span>  </div>
+                  <div class="content" id="elem-arrangement">
                      <span class="label">&lt;arrangement&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Arrangement</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2785,11 +2773,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-biogHist">
+                  <div class="leftcol">
+                     <span class="label">Biography or History</span>  </div>
+                  <div class="content" id="elem-biogHist">
                      <span class="label">&lt;biogHist&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Biography or History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2917,11 +2904,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c">
+                  <div class="leftcol">
+                     <span class="label">Component (unnumbered)</span>  </div>
+                  <div class="content" id="elem-c">
                      <span class="label">&lt;c&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (unnumbered)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3189,11 +3175,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c01">
+                  <div class="leftcol">
+                     <span class="label">Component (first level)</span>  </div>
+                  <div class="content" id="elem-c01">
                      <span class="label">&lt;c01&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (first level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3461,11 +3446,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c02">
+                  <div class="leftcol">
+                     <span class="label">Component (second level)</span>  </div>
+                  <div class="content" id="elem-c02">
                      <span class="label">&lt;c02&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (second level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3733,11 +3717,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c03">
+                  <div class="leftcol">
+                     <span class="label">Component (third level)</span>  </div>
+                  <div class="content" id="elem-c03">
                      <span class="label">&lt;c03&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (third level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4005,11 +3988,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c04">
+                  <div class="leftcol">
+                     <span class="label">Component (fourth level)</span>  </div>
+                  <div class="content" id="elem-c04">
                      <span class="label">&lt;c04&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (fourth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4277,11 +4259,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c05">
+                  <div class="leftcol">
+                     <span class="label">Component (fifth level)</span>  </div>
+                  <div class="content" id="elem-c05">
                      <span class="label">&lt;c05&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (fifth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4549,11 +4530,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c06">
+                  <div class="leftcol">
+                     <span class="label">Component (sixth level)</span>  </div>
+                  <div class="content" id="elem-c06">
                      <span class="label">&lt;c06&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (sixth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4821,11 +4801,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c07">
+                  <div class="leftcol">
+                     <span class="label">Component (seventh level)</span>  </div>
+                  <div class="content" id="elem-c07">
                      <span class="label">&lt;c07&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (seventh level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5093,11 +5072,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c08">
+                  <div class="leftcol">
+                     <span class="label">Component (eighth level)</span>  </div>
+                  <div class="content" id="elem-c08">
                      <span class="label">&lt;c08&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (eighth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5365,11 +5343,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c09">
+                  <div class="leftcol">
+                     <span class="label">Component (ninth level)</span>  </div>
+                  <div class="content" id="elem-c09">
                      <span class="label">&lt;c09&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (ninth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5637,11 +5614,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c10">
+                  <div class="leftcol">
+                     <span class="label">Component (tenth level)</span>  </div>
+                  <div class="content" id="elem-c10">
                      <span class="label">&lt;c10&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (tenth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5909,11 +5885,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c11">
+                  <div class="leftcol">
+                     <span class="label">Component (eleventh level)</span>  </div>
+                  <div class="content" id="elem-c11">
                      <span class="label">&lt;c11&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (eleventh level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6181,11 +6156,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-c12">
+                  <div class="leftcol">
+                     <span class="label">Component (twelfth level)</span>  </div>
+                  <div class="content" id="elem-c12">
                      <span class="label">&lt;c12&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Component (twelfth level)</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6449,11 +6423,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-citedRange">
+                  <div class="leftcol">
+                     <span class="label">Cited Range</span>  </div>
+                  <div class="content" id="elem-citedRange">
                      <span class="label">&lt;citedRange&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Cited Range</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6554,11 +6527,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-contact">
+                  <div class="leftcol">
+                     <span class="label">Contact</span>  </div>
+                  <div class="content" id="elem-contact">
                      <span class="label">&lt;contact&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6665,11 +6637,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-contactLine">
+                  <div class="leftcol">
+                     <span class="label">Contact Line</span>  </div>
+                  <div class="content" id="elem-contactLine">
                      <span class="label">&lt;contactLine&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact Line</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6792,11 +6763,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-container">
+                  <div class="leftcol">
+                     <span class="label">Container</span>  </div>
+                  <div class="content" id="elem-container">
                      <span class="label">&lt;container&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Container</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6949,11 +6919,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-control">
+                  <div class="leftcol">
+                     <span class="label">Control</span>  </div>
+                  <div class="content" id="elem-control">
                      <span class="label">&lt;control&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Control</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7269,11 +7238,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-conventionDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Convention Declaration</span>  </div>
+                  <div class="content" id="elem-conventionDeclaration">
                      <span class="label">&lt;conventionDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Convention Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7388,11 +7356,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-custodHist">
+                  <div class="leftcol">
+                     <span class="label">Custodial History</span>  </div>
+                  <div class="content" id="elem-custodHist">
                      <span class="label">&lt;custodHist&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Custodial History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7522,11 +7489,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-date">
+                  <div class="leftcol">
+                     <span class="label">Date</span>  </div>
+                  <div class="content" id="elem-date">
                      <span class="label">&lt;date&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7693,11 +7659,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dateRange">
+                  <div class="leftcol">
+                     <span class="label">Date Range</span>  </div>
+                  <div class="content" id="elem-dateRange">
                      <span class="label">&lt;dateRange&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Range</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7827,11 +7792,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dateSet">
+                  <div class="leftcol">
+                     <span class="label">Date Set</span>  </div>
+                  <div class="content" id="elem-dateSet">
                      <span class="label">&lt;dateSet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7932,11 +7896,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-descriptionOfComponents">
+                  <div class="leftcol">
+                     <span class="label">Description of Subordinate Components</span>  </div>
+                  <div class="content" id="elem-descriptionOfComponents">
                      <span class="label">&lt;descriptionOfComponents&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Description of Subordinate Components</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8068,11 +8031,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-descriptiveNote">
+                  <div class="leftcol">
+                     <span class="label">Descriptive Note</span>  </div>
+                  <div class="content" id="elem-descriptiveNote">
                      <span class="label">&lt;descriptiveNote&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Descriptive Note</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8168,11 +8130,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dimensions">
+                  <div class="leftcol">
+                     <span class="label">Dimensions</span>  </div>
+                  <div class="content" id="elem-dimensions">
                      <span class="label">&lt;dimensions&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Dimensions</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8280,11 +8241,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-ead">
+                  <div class="leftcol">
+                     <span class="label">Encoded Archival Description</span>  </div>
+                  <div class="content" id="elem-ead">
                      <span class="label">&lt;ead&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Encoded Archival Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8365,11 +8325,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eventDateTime">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Date and Time</span>  </div>
+                  <div class="content" id="elem-eventDateTime">
                      <span class="label">&lt;eventDateTime&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Date and Time</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8452,11 +8411,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eventDescription">
+                  <div class="leftcol">
+                     <span class="label">Event Description</span>  </div>
+                  <div class="content" id="elem-eventDescription">
                      <span class="label">&lt;eventDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Event Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8560,11 +8518,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-extent">
+                  <div class="leftcol">
+                     <span class="label">Extent</span>  </div>
+                  <div class="content" id="elem-extent">
                      <span class="label">&lt;extent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Extent</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8686,11 +8643,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-filePlan">
+                  <div class="leftcol">
+                     <span class="label">File Plan</span>  </div>
+                  <div class="content" id="elem-filePlan">
                      <span class="label">&lt;filePlan&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">File Plan</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8812,11 +8768,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-findAidDesc">
+                  <div class="leftcol">
+                     <span class="label">Finding Aid Description</span>  </div>
+                  <div class="content" id="elem-findAidDesc">
                      <span class="label">&lt;findAidDesc&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Finding Aid Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8957,11 +8912,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-formattingExtension">
+                  <div class="leftcol">
+                     <span class="label">Formatting Extension</span>  </div>
+                  <div class="content" id="elem-formattingExtension">
                      <span class="label">&lt;formattingExtension&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Formatting Extension</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9021,11 +8975,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-formAvailable">
+                  <div class="leftcol">
+                     <span class="label">Form Available</span>  </div>
+                  <div class="content" id="elem-formAvailable">
                      <span class="label">&lt;formAvailable&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Form Available</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9267,11 +9220,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-formAvailableId">
+                  <div class="leftcol">
+                     <span class="label">Identifier of the Form Available</span>  </div>
+                  <div class="content" id="elem-formAvailableId">
                      <span class="label">&lt;formAvailableId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identifier of the Form Available</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9418,11 +9370,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-formsAvailable">
+                  <div class="leftcol">
+                     <span class="label">Forms Available</span>  </div>
+                  <div class="content" id="elem-formsAvailable">
                      <span class="label">&lt;formsAvailable&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Forms Available</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9533,11 +9484,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-fromDate">
+                  <div class="leftcol">
+                     <span class="label">From Date</span>  </div>
+                  <div class="content" id="elem-fromDate">
                      <span class="label">&lt;fromDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">From Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9717,11 +9667,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-function">
+                  <div class="leftcol">
+                     <span class="label">Function</span>  </div>
+                  <div class="content" id="elem-function">
                      <span class="label">&lt;function&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9876,11 +9825,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functions">
+                  <div class="leftcol">
+                     <span class="label">Functions</span>  </div>
+                  <div class="content" id="elem-functions">
                      <span class="label">&lt;functions&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Functions</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9992,11 +9940,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-genreForm">
+                  <div class="leftcol">
+                     <span class="label">Genre or Form</span>  </div>
+                  <div class="content" id="elem-genreForm">
                      <span class="label">&lt;genreForm&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Genre or Form</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10140,11 +10087,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-geographicCoordinates">
+                  <div class="leftcol">
+                     <span class="label">Geographic Coordinates</span>  </div>
+                  <div class="content" id="elem-geographicCoordinates">
                      <span class="label">&lt;geographicCoordinates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Geographic Coordinates</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10245,11 +10191,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-head">
+                  <div class="leftcol">
+                     <span class="label">Heading</span>  </div>
+                  <div class="content" id="elem-head">
                      <span class="label">&lt;head&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Heading</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10352,11 +10297,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-identificationData">
+                  <div class="leftcol">
+                     <span class="label">Identification Data</span>  </div>
+                  <div class="content" id="elem-identificationData">
                      <span class="label">&lt;identificationData&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identification Data</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10508,11 +10452,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-label">
+                  <div class="leftcol">
+                     <span class="label">Label</span>  </div>
+                  <div class="content" id="elem-label">
                      <span class="label">&lt;label&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Label</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10642,11 +10585,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-language">
+                  <div class="leftcol">
+                     <span class="label">Language</span>  </div>
+                  <div class="content" id="elem-language">
                      <span class="label">&lt;language&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10753,11 +10695,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languageDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Language Declaration</span>  </div>
+                  <div class="content" id="elem-languageDeclaration">
                      <span class="label">&lt;languageDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10853,11 +10794,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languageOfMaterial">
+                  <div class="leftcol">
+                     <span class="label">Language of Material</span>  </div>
+                  <div class="content" id="elem-languageOfMaterial">
                      <span class="label">&lt;languageOfMaterial&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language of Material</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -10962,11 +10902,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languageSet">
+                  <div class="leftcol">
+                     <span class="label">Language Set</span>  </div>
+                  <div class="content" id="elem-languageSet">
                      <span class="label">&lt;languageSet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11074,11 +11013,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-legalStatus">
+                  <div class="leftcol">
+                     <span class="label">Legal Status</span>  </div>
+                  <div class="content" id="elem-legalStatus">
                      <span class="label">&lt;legalStatus&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Legal Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11224,11 +11162,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-localTypeDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Local Type Declaration</span>  </div>
+                  <div class="content" id="elem-localTypeDeclaration">
                      <span class="label">&lt;localTypeDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11342,11 +11279,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceAgency">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Agency</span>  </div>
+                  <div class="content" id="elem-maintenanceAgency">
                      <span class="label">&lt;maintenanceAgency&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Agency</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11485,11 +11421,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceEvent">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event</span>  </div>
+                  <div class="content" id="elem-maintenanceEvent">
                      <span class="label">&lt;maintenanceEvent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11593,11 +11528,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceHistory">
+                  <div class="leftcol">
+                     <span class="label">Maintenance History</span>  </div>
+                  <div class="content" id="elem-maintenanceHistory">
                      <span class="label">&lt;maintenanceHistory&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11673,11 +11607,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-narrativeEvent">
+                  <div class="leftcol">
+                     <span class="label">Narrative Event</span>  </div>
+                  <div class="content" id="elem-narrativeEvent">
                      <span class="label">&lt;narrativeEvent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Narrative Event</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11803,11 +11736,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-objectXMLWrap">
+                  <div class="leftcol">
+                     <span class="label">Object XML Wrap</span>  </div>
+                  <div class="content" id="elem-objectXMLWrap">
                      <span class="label">&lt;objectXMLWrap&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Object XML Wrap</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11867,11 +11799,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherAgencyCode">
+                  <div class="leftcol">
+                     <span class="label">Other Agency Code</span>  </div>
+                  <div class="content" id="elem-otherAgencyCode">
                      <span class="label">&lt;otherAgencyCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Agency Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -11989,11 +11920,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherDescription">
+                  <div class="leftcol">
+                     <span class="label">Other Description</span>  </div>
+                  <div class="content" id="elem-otherDescription">
                      <span class="label">&lt;otherDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12151,11 +12081,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherDescriptiveInfo">
+                  <div class="leftcol">
+                     <span class="label">Other Descriptive Information</span>  </div>
+                  <div class="content" id="elem-otherDescriptiveInfo">
                      <span class="label">&lt;otherDescriptiveInfo&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Descriptive Information</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12288,11 +12217,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherIdentificationData">
+                  <div class="leftcol">
+                     <span class="label">Other Identification Data</span>  </div>
+                  <div class="content" id="elem-otherIdentificationData">
                      <span class="label">&lt;otherIdentificationData&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Identification Data</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12421,11 +12349,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherRecordId">
+                  <div class="leftcol">
+                     <span class="label">Other Record Identifier</span>  </div>
+                  <div class="content" id="elem-otherRecordId">
                      <span class="label">&lt;otherRecordId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Record Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12534,11 +12461,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-p">
+                  <div class="leftcol">
+                     <span class="label">Paragraph</span>  </div>
+                  <div class="content" id="elem-p">
                      <span class="label">&lt;p&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Paragraph</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12644,11 +12570,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-part">
+                  <div class="leftcol">
+                     <span class="label">Part</span>  </div>
+                  <div class="content" id="elem-part">
                      <span class="label">&lt;part&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Part</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12756,11 +12681,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-physicalDescription">
+                  <div class="leftcol">
+                     <span class="label">Physical Description</span>  </div>
+                  <div class="content" id="elem-physicalDescription">
                      <span class="label">&lt;physicalDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Physical Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -12879,11 +12803,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-physicalFacet">
+                  <div class="leftcol">
+                     <span class="label">Physical Facet</span>  </div>
+                  <div class="content" id="elem-physicalFacet">
                      <span class="label">&lt;physicalFacet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Physical Facet</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13027,11 +12950,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-physicalOrTechnicalRequirements">
+                  <div class="leftcol">
+                     <span class="label">Physical Characteristics or Technical Requirements</span>  </div>
+                  <div class="content" id="elem-physicalOrTechnicalRequirements">
                      <span class="label">&lt;physicalOrTechnicalRequirements&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Physical Characteristics or Technical Requirements</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13148,11 +13070,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-place">
+                  <div class="leftcol">
+                     <span class="label">Place</span>  </div>
+                  <div class="content" id="elem-place">
                      <span class="label">&lt;place&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13320,11 +13241,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-placeName">
+                  <div class="leftcol">
+                     <span class="label">Place Name</span>  </div>
+                  <div class="content" id="elem-placeName">
                      <span class="label">&lt;placeName&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Name</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13460,11 +13380,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-places">
+                  <div class="leftcol">
+                     <span class="label">Places</span>  </div>
+                  <div class="content" id="elem-places">
                      <span class="label">&lt;places&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Places</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13575,11 +13494,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-preferCite">
+                  <div class="leftcol">
+                     <span class="label">Preferred Citation</span>  </div>
+                  <div class="content" id="elem-preferCite">
                      <span class="label">&lt;preferCite&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Preferred Citation</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13697,11 +13615,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-processInfo">
+                  <div class="leftcol">
+                     <span class="label">Processing Information</span>  </div>
+                  <div class="content" id="elem-processInfo">
                      <span class="label">&lt;processInfo&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Processing Information</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13832,11 +13749,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-publicationNote">
+                  <div class="leftcol">
+                     <span class="label">Publication Note</span>  </div>
+                  <div class="content" id="elem-publicationNote">
                      <span class="label">&lt;publicationNote&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Note</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -13988,11 +13904,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-quantity">
+                  <div class="leftcol">
+                     <span class="label">Quantity</span>  </div>
+                  <div class="content" id="elem-quantity">
                      <span class="label">&lt;quantity&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Quantity</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14086,11 +14001,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-recordId">
+                  <div class="leftcol">
+                     <span class="label">Record Identifier</span>  </div>
+                  <div class="content" id="elem-recordId">
                      <span class="label">&lt;recordId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Record Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14167,11 +14081,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-recordTypeSpecificStatement">
+                  <div class="leftcol">
+                     <span class="label">Record Type Specific Statement</span>  </div>
+                  <div class="content" id="elem-recordTypeSpecificStatement">
                      <span class="label">&lt;recordTypeSpecificStatement&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Record Type Specific Statement</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14297,11 +14210,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-reference">
+                  <div class="leftcol">
+                     <span class="label">Reference</span>  </div>
+                  <div class="content" id="elem-reference">
                      <span class="label">&lt;reference&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14447,11 +14359,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-referringString">
+                  <div class="leftcol">
+                     <span class="label">Referring String</span>  </div>
+                  <div class="content" id="elem-referringString">
                      <span class="label">&lt;referringString&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referring String</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14601,11 +14512,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relatedMaterial">
+                  <div class="leftcol">
+                     <span class="label">Related Material</span>  </div>
+                  <div class="content" id="elem-relatedMaterial">
                      <span class="label">&lt;relatedMaterial&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Related Material</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14762,11 +14672,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relation">
+                  <div class="leftcol">
+                     <span class="label">Relation</span>  </div>
+                  <div class="content" id="elem-relation">
                      <span class="label">&lt;relation&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -14911,11 +14820,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relations">
+                  <div class="leftcol">
+                     <span class="label">Relations</span>  </div>
+                  <div class="content" id="elem-relations">
                      <span class="label">&lt;relations&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relations</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15014,11 +14922,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relationship">
+                  <div class="leftcol">
+                     <span class="label">Relationship</span>  </div>
+                  <div class="content" id="elem-relationship">
                      <span class="label">&lt;relationship&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relationship</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15147,11 +15054,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-rightsDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Rights Declaration</span>  </div>
+                  <div class="content" id="elem-rightsDeclaration">
                      <span class="label">&lt;rightsDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Rights Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15263,11 +15169,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-role">
+                  <div class="leftcol">
+                     <span class="label">Role</span>  </div>
+                  <div class="content" id="elem-role">
                      <span class="label">&lt;role&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Role</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15378,11 +15283,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-scopeContent">
+                  <div class="leftcol">
+                     <span class="label">Scope and Content</span>  </div>
+                  <div class="content" id="elem-scopeContent">
                      <span class="label">&lt;scopeContent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Scope and Content</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15501,11 +15405,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-separatedMaterial">
+                  <div class="leftcol">
+                     <span class="label">Separated Material</span>  </div>
+                  <div class="content" id="elem-separatedMaterial">
                      <span class="label">&lt;separatedMaterial&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Separated Material</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15654,11 +15557,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-shortCode">
+                  <div class="leftcol">
+                     <span class="label">Short Code</span>  </div>
+                  <div class="content" id="elem-shortCode">
                      <span class="label">&lt;shortCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Short Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15727,11 +15629,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-source">
+                  <div class="leftcol">
+                     <span class="label">Source</span>  </div>
+                  <div class="content" id="elem-source">
                      <span class="label">&lt;source&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -15872,11 +15773,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-sourceOfAcquisition">
+                  <div class="leftcol">
+                     <span class="label">Source Of Acquisition</span>  </div>
+                  <div class="content" id="elem-sourceOfAcquisition">
                      <span class="label">&lt;sourceOfAcquisition&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source Of Acquisition</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16005,11 +15905,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-sources">
+                  <div class="leftcol">
+                     <span class="label">Sources</span>  </div>
+                  <div class="content" id="elem-sources">
                      <span class="label">&lt;sources&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Sources</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16090,11 +15989,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-span">
+                  <div class="leftcol">
+                     <span class="label">span</span>  </div>
+                  <div class="content" id="elem-span">
                      <span class="label">&lt;span&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">span</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16207,11 +16105,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-subject">
+                  <div class="leftcol">
+                     <span class="label">Subject</span>  </div>
+                  <div class="content" id="elem-subject">
                      <span class="label">&lt;subject&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Subject</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16357,11 +16254,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-subjectHeadings">
+                  <div class="leftcol">
+                     <span class="label">Subject Headings</span>  </div>
+                  <div class="content" id="elem-subjectHeadings">
                      <span class="label">&lt;subjectHeadings&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Subject Headings</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16485,11 +16381,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-term">
+                  <div class="leftcol">
+                     <span class="label">Term</span>  </div>
+                  <div class="content" id="elem-term">
                      <span class="label">&lt;term&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Term</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16578,11 +16473,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-textualDate">
+                  <div class="leftcol">
+                     <span class="label">Textual Date</span>  </div>
+                  <div class="content" id="elem-textualDate">
                      <span class="label">&lt;textualDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Textual Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16697,11 +16591,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-title">
+                  <div class="leftcol">
+                     <span class="label">Title</span>  </div>
+                  <div class="content" id="elem-title">
                      <span class="label">&lt;title&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Title</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -16839,11 +16732,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-toDate">
+                  <div class="leftcol">
+                     <span class="label">To Date</span>  </div>
+                  <div class="content" id="elem-toDate">
                      <span class="label">&lt;toDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">To Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17003,11 +16895,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-unitDate">
+                  <div class="leftcol">
+                     <span class="label">Date of the Unit</span>  </div>
+                  <div class="content" id="elem-unitDate">
                      <span class="label">&lt;unitDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date of the Unit</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17135,11 +17026,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-unitId">
+                  <div class="leftcol">
+                     <span class="label">Identifier of the Unit</span>  </div>
+                  <div class="content" id="elem-unitId">
                      <span class="label">&lt;unitId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identifier of the Unit</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17299,11 +17189,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-unitOfMeasurement">
+                  <div class="leftcol">
+                     <span class="label">Unit of Measurement</span>  </div>
+                  <div class="content" id="elem-unitOfMeasurement">
                      <span class="label">&lt;unitOfMeasurement&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Unit of Measurement</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17417,11 +17306,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-unitTitle">
+                  <div class="leftcol">
+                     <span class="label">Title of the Unit</span>  </div>
+                  <div class="content" id="elem-unitTitle">
                      <span class="label">&lt;unitTitle&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Title of the Unit</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17562,11 +17450,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-useConditions">
+                  <div class="leftcol">
+                     <span class="label">Conditions Governing Use</span>  </div>
+                  <div class="content" id="elem-useConditions">
                      <span class="label">&lt;useConditions&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Conditions Governing Use</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17713,11 +17600,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-writingSystem">
+                  <div class="leftcol">
+                     <span class="label">Writing System</span>  </div>
+                  <div class="content" id="elem-writingSystem">
                      <span class="label">&lt;writingSystem&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Writing System</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17822,11 +17708,10 @@
             <div class="section" id="d1e11637">
                <div class="head03">Attributes</div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-addressLineType">
+                  <div class="leftcol">
+                     <span class="label">Address Line Type</span>  </div>
+                  <div class="content" id="attr-addressLineType">
                      <span class="label">@addressLineType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address Line Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17848,11 +17733,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-addressLineTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Address Line Type Encoding</span>  </div>
+                  <div class="content" id="attr-addressLineTypeEncoding">
                      <span class="label">@addressLineTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Address Line Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17874,11 +17758,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-agentType">
+                  <div class="leftcol">
+                     <span class="label">Agent Type</span>  </div>
+                  <div class="content" id="attr-agentType">
                      <span class="label">@agentType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17900,11 +17783,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-agentTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Agent Type Encoding</span>  </div>
+                  <div class="content" id="attr-agentTypeEncoding">
                      <span class="label">@agentTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17926,11 +17808,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-approximate">
+                  <div class="leftcol">
+                     <span class="label">Approximate</span>  </div>
+                  <div class="content" id="attr-approximate">
                      <span class="label">@approximate</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Approximate</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17945,11 +17826,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-audience">
+                  <div class="leftcol">
+                     <span class="label">Audience</span>  </div>
+                  <div class="content" id="attr-audience">
                      <span class="label">@audience</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Audience</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17971,11 +17851,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-audienceEncoding">
+                  <div class="leftcol">
+                     <span class="label">Audience Encoding</span>  </div>
+                  <div class="content" id="attr-audienceEncoding">
                      <span class="label">@audienceEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Audience Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -17997,11 +17876,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-calendar">
+                  <div class="leftcol">
+                     <span class="label">Calendar</span>  </div>
+                  <div class="content" id="attr-calendar">
                      <span class="label">@calendar</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Calendar</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18023,11 +17901,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-certainty">
+                  <div class="leftcol">
+                     <span class="label">Certainty</span>  </div>
+                  <div class="content" id="attr-certainty">
                      <span class="label">@certainty</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Certainty</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18051,11 +17928,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-contactLineType">
+                  <div class="leftcol">
+                     <span class="label">Contact Line Type</span>  </div>
+                  <div class="content" id="attr-contactLineType">
                      <span class="label">@contactLineType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact Line Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18077,11 +17953,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-contactLineTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Contact Line Type Encoding</span>  </div>
+                  <div class="content" id="attr-contactLineTypeEncoding">
                      <span class="label">@contactLineTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Contact Line Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18103,11 +17978,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-containerId">
+                  <div class="leftcol">
+                     <span class="label">Container ID</span>  </div>
+                  <div class="content" id="attr-containerId">
                      <span class="label">@containerId</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Container ID</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18124,11 +17998,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-conventionDeclarationReference">
+                  <div class="leftcol">
+                     <span class="label">Convention Declaration Reference</span>  </div>
+                  <div class="content" id="attr-conventionDeclarationReference">
                      <span class="label">@conventionDeclarationReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Convention Declaration Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18156,11 +18029,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-coordinateSystem">
+                  <div class="leftcol">
+                     <span class="label">Coordinate System</span>  </div>
+                  <div class="content" id="attr-coordinateSystem">
                      <span class="label">@coordinateSystem</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Coordinate System</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18183,11 +18055,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-countryCode">
+                  <div class="leftcol">
+                     <span class="label">Country Code</span>  </div>
+                  <div class="content" id="attr-countryCode">
                      <span class="label">@countryCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Country Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18209,11 +18080,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-countryEncoding">
+                  <div class="leftcol">
+                     <span class="label">Country Encoding</span>  </div>
+                  <div class="content" id="attr-countryEncoding">
                      <span class="label">@countryEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Country Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18236,11 +18106,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-coverage">
+                  <div class="leftcol">
+                     <span class="label">Coverage</span>  </div>
+                  <div class="content" id="attr-coverage">
                      <span class="label">@coverage</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Coverage</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18263,11 +18132,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-coverageEncoding">
+                  <div class="leftcol">
+                     <span class="label">coverageEncoding</span>  </div>
+                  <div class="content" id="attr-coverageEncoding">
                      <span class="label">@coverageEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">coverageEncoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18289,11 +18157,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-dateChar">
+                  <div class="leftcol">
+                     <span class="label">Date Characterization</span>  </div>
+                  <div class="content" id="attr-dateChar">
                      <span class="label">@dateChar</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Characterization</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18308,11 +18175,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-dateEncoding">
+                  <div class="leftcol">
+                     <span class="label">Date Encoding</span>  </div>
+                  <div class="content" id="attr-dateEncoding">
                      <span class="label">@dateEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18335,11 +18201,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-descriptionOfComponentsType">
+                  <div class="leftcol">
+                     <span class="label">Description of Subordinate Components Type</span>  </div>
+                  <div class="content" id="attr-descriptionOfComponentsType">
                      <span class="label">@descriptionOfComponentsType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Description of Subordinate Components Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18356,11 +18221,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-descriptionOfComponentsTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Description Of Components Type Encoding</span>  </div>
+                  <div class="content" id="attr-descriptionOfComponentsTypeEncoding">
                      <span class="label">@descriptionOfComponentsTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Description Of Components Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18382,11 +18246,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-detailLevel">
+                  <div class="leftcol">
+                     <span class="label">Level of Detail</span>  </div>
+                  <div class="content" id="attr-detailLevel">
                      <span class="label">@detailLevel</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Level of Detail</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18408,11 +18271,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-detailLevelEncoding">
+                  <div class="leftcol">
+                     <span class="label">Detail Level Encoding</span>  </div>
+                  <div class="content" id="attr-detailLevelEncoding">
                      <span class="label">@detailLevelEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Detail Level Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18434,11 +18296,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-era">
+                  <div class="leftcol">
+                     <span class="label">Era</span>  </div>
+                  <div class="content" id="attr-era">
                      <span class="label">@era</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Era</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18459,11 +18320,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-extentType">
+                  <div class="leftcol">
+                     <span class="label">Extent Type</span>  </div>
+                  <div class="content" id="attr-extentType">
                      <span class="label">@extentType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Extent Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18485,11 +18345,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-extentTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Extent Type Encoding</span>  </div>
+                  <div class="content" id="attr-extentTypeEncoding">
                      <span class="label">@extentTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Extent Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18511,11 +18370,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-formAvailableType">
+                  <div class="leftcol">
+                     <span class="label">Form Available Type</span>  </div>
+                  <div class="content" id="attr-formAvailableType">
                      <span class="label">@formAvailableType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Form Available Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18537,11 +18395,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-formAvailableTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Form Available Type Encoding</span>  </div>
+                  <div class="content" id="attr-formAvailableTypeEncoding">
                      <span class="label">@formAvailableTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Form Available Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18563,11 +18420,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-functionType">
+                  <div class="leftcol">
+                     <span class="label">Function Type</span>  </div>
+                  <div class="content" id="attr-functionType">
                      <span class="label">@functionType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18587,11 +18443,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-functionTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Function Type Encoding</span>  </div>
+                  <div class="content" id="attr-functionTypeEncoding">
                      <span class="label">@functionTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18613,11 +18468,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-href">
+                  <div class="leftcol">
+                     <span class="label">Hypertext Reference</span>  </div>
+                  <div class="content" id="attr-href">
                      <span class="label">@href</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Hypertext Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18640,11 +18494,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-id">
+                  <div class="leftcol">
+                     <span class="label">ID</span>  </div>
+                  <div class="content" id="attr-id">
                      <span class="label">@id</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">ID</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18668,11 +18521,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageCode">
+                  <div class="leftcol">
+                     <span class="label">Language Code</span>  </div>
+                  <div class="content" id="attr-languageCode">
                      <span class="label">@languageCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18693,11 +18545,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageEncoding">
+                  <div class="leftcol">
+                     <span class="label">Language Encoding</span>  </div>
+                  <div class="content" id="attr-languageEncoding">
                      <span class="label">@languageEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18720,11 +18571,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageOfElement">
+                  <div class="leftcol">
+                     <span class="label">Language of Element</span>  </div>
+                  <div class="content" id="attr-languageOfElement">
                      <span class="label">@languageOfElement</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language of Element</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18746,11 +18596,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-level">
+                  <div class="leftcol">
+                     <span class="label">Level</span>  </div>
+                  <div class="content" id="attr-level">
                      <span class="label">@level</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Level</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18767,11 +18616,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-levelEncoding">
+                  <div class="leftcol">
+                     <span class="label">Level Encoding</span>  </div>
+                  <div class="content" id="attr-levelEncoding">
                      <span class="label">@levelEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Level Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18793,11 +18641,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-linkRole">
+                  <div class="leftcol">
+                     <span class="label">Link Role</span>  </div>
+                  <div class="content" id="attr-linkRole">
                      <span class="label">@linkRole</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Link Role</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18822,11 +18669,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-linkTitle">
+                  <div class="leftcol">
+                     <span class="label">Link Title</span>  </div>
+                  <div class="content" id="attr-linkTitle">
                      <span class="label">@linkTitle</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Link Title</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18852,11 +18698,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-localType">
+                  <div class="leftcol">
+                     <span class="label">Local Type</span>  </div>
+                  <div class="content" id="attr-localType">
                      <span class="label">@localType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18889,11 +18734,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-localTypeDeclarationReference">
+                  <div class="leftcol">
+                     <span class="label">Local Type Declaration Reference</span>  </div>
+                  <div class="content" id="attr-localTypeDeclarationReference">
                      <span class="label">@localTypeDeclarationReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type Declaration Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18920,11 +18764,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventReference">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Reference</span>  </div>
+                  <div class="content" id="attr-maintenanceEventReference">
                      <span class="label">@maintenanceEventReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18947,11 +18790,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventType">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Type</span>  </div>
+                  <div class="content" id="attr-maintenanceEventType">
                      <span class="label">@maintenanceEventType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18973,11 +18815,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Type Encoding</span>  </div>
+                  <div class="content" id="attr-maintenanceEventTypeEncoding">
                      <span class="label">@maintenanceEventTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -18999,11 +18840,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceStatus">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Status</span>  </div>
+                  <div class="content" id="attr-maintenanceStatus">
                      <span class="label">@maintenanceStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19022,11 +18862,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Status Encoding</span>  </div>
+                  <div class="content" id="attr-maintenanceStatusEncoding">
                      <span class="label">@maintenanceStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19048,11 +18887,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-normalizedForm">
+                  <div class="leftcol">
+                     <span class="label">Normalized Form</span>  </div>
+                  <div class="content" id="attr-normalizedForm">
                      <span class="label">@normalizedForm</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Normalized Form</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19073,11 +18911,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-notAfter">
+                  <div class="leftcol">
+                     <span class="label">Not After</span>  </div>
+                  <div class="content" id="attr-notAfter">
                      <span class="label">@notAfter</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Not After</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19098,11 +18935,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-notBefore">
+                  <div class="leftcol">
+                     <span class="label">Not Before</span>  </div>
+                  <div class="content" id="attr-notBefore">
                      <span class="label">@notBefore</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Not Before</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19123,11 +18959,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-placeType">
+                  <div class="leftcol">
+                     <span class="label">Place Type</span>  </div>
+                  <div class="content" id="attr-placeType">
                      <span class="label">@placeType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19147,11 +18982,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-placeTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Place Type Encoding</span>  </div>
+                  <div class="content" id="attr-placeTypeEncoding">
                      <span class="label">@placeTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19173,11 +19007,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-publicationStatus">
+                  <div class="leftcol">
+                     <span class="label">Publication Status</span>  </div>
+                  <div class="content" id="attr-publicationStatus">
                      <span class="label">@publicationStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19199,11 +19032,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-publicationStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Publication Status Encoding</span>  </div>
+                  <div class="content" id="attr-publicationStatusEncoding">
                      <span class="label">@publicationStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19225,11 +19057,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityRelationship">
+                  <div class="leftcol">
+                     <span class="label">Referred Entity Relationship</span>  </div>
+                  <div class="content" id="attr-referredEntityRelationship">
                      <span class="label">@referredEntityRelationship</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referred Entity Relationship</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19247,11 +19078,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityType">
+                  <div class="leftcol">
+                     <span class="label">Referrered Entity Type</span>  </div>
+                  <div class="content" id="attr-referredEntityType">
                      <span class="label">@referredEntityType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referrered Entity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19273,11 +19103,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Referred Entity Type Encoding</span>  </div>
+                  <div class="content" id="attr-referredEntityTypeEncoding">
                      <span class="label">@referredEntityTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referred Entity Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19299,11 +19128,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-relationType">
+                  <div class="leftcol">
+                     <span class="label">Relation Type</span>  </div>
+                  <div class="content" id="attr-relationType">
                      <span class="label">@relationType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19325,11 +19153,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-relationTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Relation Type Encoding</span>  </div>
+                  <div class="content" id="attr-relationTypeEncoding">
                      <span class="label">@relationTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19351,11 +19178,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-repositoryCode">
+                  <div class="leftcol">
+                     <span class="label">Repository Code</span>  </div>
+                  <div class="content" id="attr-repositoryCode">
                      <span class="label">@repositoryCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Repository Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19376,11 +19202,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-repositoryEncoding">
+                  <div class="leftcol">
+                     <span class="label">Repository Encoding</span>  </div>
+                  <div class="content" id="attr-repositoryEncoding">
                      <span class="label">@repositoryEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Repository Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19403,11 +19228,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptCode">
+                  <div class="leftcol">
+                     <span class="label">Script Code</span>  </div>
+                  <div class="content" id="attr-scriptCode">
                      <span class="label">@scriptCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19428,11 +19252,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptEncoding">
+                  <div class="leftcol">
+                     <span class="label">Script Encoding</span>  </div>
+                  <div class="content" id="attr-scriptEncoding">
                      <span class="label">@scriptEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19454,11 +19277,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptOfElement">
+                  <div class="leftcol">
+                     <span class="label">Script of Element</span>  </div>
+                  <div class="content" id="attr-scriptOfElement">
                      <span class="label">@scriptOfElement</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script of Element</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19479,11 +19301,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-sourceReference">
+                  <div class="leftcol">
+                     <span class="label">Source Reference</span>  </div>
+                  <div class="content" id="attr-sourceReference">
                      <span class="label">@sourceReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19508,11 +19329,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-standardDate">
+                  <div class="leftcol">
+                     <span class="label">Standard Date</span>  </div>
+                  <div class="content" id="attr-standardDate">
                      <span class="label">@standardDate</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Standard Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19533,11 +19353,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-standardDateTime">
+                  <div class="leftcol">
+                     <span class="label">Standard Date and Time</span>  </div>
+                  <div class="content" id="attr-standardDateTime">
                      <span class="label">@standardDateTime</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Standard Date and Time</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19565,11 +19384,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-status">
+                  <div class="leftcol">
+                     <span class="label">Status</span>  </div>
+                  <div class="content" id="attr-status">
                      <span class="label">@status</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19592,11 +19410,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-statusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Status Encoding</span>  </div>
+                  <div class="content" id="attr-statusEncoding">
                      <span class="label">@statusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19622,11 +19439,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-style">
+                  <div class="leftcol">
+                     <span class="label">Style</span>  </div>
+                  <div class="content" id="attr-style">
                      <span class="label">@style</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Style</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19648,11 +19464,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-target">
+                  <div class="leftcol">
+                     <span class="label">Target</span>  </div>
+                  <div class="content" id="attr-target">
                      <span class="label">@target</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19673,11 +19488,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-targetType">
+                  <div class="leftcol">
+                     <span class="label">Target Type</span>  </div>
+                  <div class="content" id="attr-targetType">
                      <span class="label">@targetType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19697,11 +19511,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-targetTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Target Type Encoding</span>  </div>
+                  <div class="content" id="attr-targetTypeEncoding">
                      <span class="label">@targetTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19723,11 +19536,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-unit">
+                  <div class="leftcol">
+                     <span class="label">Unit</span>  </div>
+                  <div class="content" id="attr-unit">
                      <span class="label">@unit</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Unit</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19748,11 +19560,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-unitDateType">
+                  <div class="leftcol">
+                     <span class="label">Unit Date Type</span>  </div>
+                  <div class="content" id="attr-unitDateType">
                      <span class="label">@unitDateType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Unit Date Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19774,11 +19585,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-unitDateTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Unit Date Type Encoding</span>  </div>
+                  <div class="content" id="attr-unitDateTypeEncoding">
                      <span class="label">@unitDateTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Unit Date Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19800,11 +19610,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-valueURI">
+                  <div class="leftcol">
+                     <span class="label">Value URI</span>  </div>
+                  <div class="content" id="attr-valueURI">
                      <span class="label">@valueURI</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Value URI</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19826,11 +19635,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-vocabularySource">
+                  <div class="leftcol">
+                     <span class="label">Vocabulary Source</span>  </div>
+                  <div class="content" id="attr-vocabularySource">
                      <span class="label">@vocabularySource</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Vocabulary Source</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -19851,11 +19659,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-vocabularySourceURI">
+                  <div class="leftcol">
+                     <span class="label">Vocabulary Source URI</span>  </div>
+                  <div class="content" id="attr-vocabularySourceURI">
                      <span class="label">@vocabularySourceURI</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Vocabulary Source URI</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">

--- a/html/EAD4-TL-eng.html
+++ b/html/EAD4-TL-eng.html
@@ -8321,8 +8321,6 @@
                   <div class="content">
                      <div class="p">Required, not repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -10293,8 +10291,6 @@
                   <div class="content">
                      <div class="p">Optional, not repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -13066,8 +13062,6 @@
                   <div class="content">
                      <div class="p">Optional, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -16250,8 +16244,6 @@
                   <div class="content">
                      <div class="p">Optional, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -17446,8 +17438,6 @@
                   <div class="content">
                      <div class="p">Optional, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -17821,8 +17811,6 @@
                   <div class="content">
                      <div class="p">false, true</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -17896,8 +17884,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -18170,8 +18156,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -18315,8 +18299,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -18438,8 +18420,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -18977,8 +18957,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -19506,8 +19484,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">

--- a/html/EAF1-TL-eng.html
+++ b/html/EAF1-TL-eng.html
@@ -2588,8 +2588,6 @@
                      <div class="p">Within <a href="#elem-agent">&lt;agent&gt;</a>, <a href="#elem-legislation">&lt;legislation&gt;</a>, <a href="#elem-relation">&lt;relation&gt;</a>: one of <a href="#elem-date">&lt;date&gt;</a>, <a href="#elem-dateRange">&lt;dateRange&gt;</a>, or <a href="#elem-dateSet">&lt;dateSet&gt;</a> optional, not repeatable</div>
                      <div class="p">Within <a href="#elem-useDates">&lt;useDates&gt;</a>: one of <a href="#elem-date">&lt;date&gt;</a>, <a href="#elem-dateRange">&lt;dateRange&gt;</a>, or <a href="#elem-dateSet">&lt;dateSet&gt;</a> required, not repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -3148,8 +3146,6 @@
                      <div class="p">Optional, not repeatable</div>
                      <div class="p">In these narrative contexts, the encoder must choose between using a <a href="#elem-formattingExtention">&lt;formattingExtention&gt;</a> element (to wrap XHTML content), or using one or more <a href="#elem-p">&lt;p&gt;</a> elements that are defined within the current EAS schema.</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -5450,8 +5446,6 @@
                      <div class="p">Within <a href="#elem-identity">&lt;identity&gt;</a>: one of <a href="#elem-nameEntry">&lt;nameEntry&gt;</a> or <a href="#elem-nameEntrySet">&lt;nameEntrySet&gt;</a> required,
          repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -5511,8 +5505,6 @@
                   <div class="content">
                      <div class="p">Optional, not repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -5981,8 +5973,6 @@
                   <div class="content">
                      <div class="p">Use the attributes <a href="#attr-valueURI">@valueURI</a>, <a href="#attr-vocabularySource">@vocabularySource</a>, and <a href="#attr-vocabularySourceURI">@vocabularySourceURI</a> with <a href="#elem-placeName">&lt;placeName&gt;</a> when referencing an entry of an external vocabulary, thesaurus, ontology.</div>
                   </div>
-                  <div class="leftcol">See also: </div>
-                  <div class="content"/>
                   <div class="leftcol">May contain: </div>
                   <div class="content">
                      <table>
@@ -6099,8 +6089,6 @@
                   <div class="content">
                      <div class="p">Optional, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -7089,8 +7077,6 @@
                   <div class="content">
                      <div class="p">Optional, repeatable</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="element">
                   <div class="leftcol">
@@ -7836,8 +7822,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -7886,8 +7870,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -7966,8 +7948,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8041,8 +8021,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8090,8 +8068,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8213,8 +8189,6 @@
                      <div class="p">The <a href="#attr-identityType">@identityType</a> may occur on <a href="#elem-identity">&lt;identity&gt;</a>.</div>
                      <div class="p">Use the attribute <a href="#attr-identityTypeEncoding">@identityTypeEncoding</a> in <a href="#elem-control">&lt;control&gt;</a> to identify the list of authoritative terms that can be used as values of <a href="#attr-identityType">@identityType</a>.</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8260,8 +8234,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8309,8 +8281,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8334,8 +8304,6 @@
                   <div class="content">
                      <div class="p">anyURI</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8360,8 +8328,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8424,8 +8390,6 @@
                   <div class="content">
                      <div class="p">IDREFS</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8448,8 +8412,6 @@
                   <div class="content">
                      <div class="p">IDREFS</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8567,8 +8529,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8589,8 +8549,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8611,8 +8569,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8636,8 +8592,6 @@
                   <div class="content">
                      <div class="p">false, true</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8855,8 +8809,6 @@
                   <div class="content">
                      <div class="p">token</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -8930,8 +8882,6 @@
                   <div class="content">
                      <div class="p">IDREFS</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -9062,8 +9012,6 @@
                   <div class="content">
                      <div class="p">normalizedString</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
@@ -9084,8 +9032,6 @@
                   <div class="content">
                      <div class="p">IDREFS</div>
                   </div>
-                  <div class="leftcol">Examples: </div>
-                  <div class="content"/>
                </div>
                <div class="spacer"> </div>
                <div class="attribute">

--- a/html/EAF1-TL-eng.html
+++ b/html/EAF1-TL-eng.html
@@ -1093,11 +1093,10 @@
             <div class="section" id="d1e196">
                <div class="head03">Elements</div>
                <div class="element">
-                  <div class="leftcol" id="elem-agencyCode">
+                  <div class="leftcol">
+                     <span class="label">Agency Code</span>  </div>
+                  <div class="content" id="elem-agencyCode">
                      <span class="label">&lt;agencyCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agency Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1204,11 +1203,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agencyName">
+                  <div class="leftcol">
+                     <span class="label">Agency Name</span>  </div>
+                  <div class="content" id="elem-agencyName">
                      <span class="label">&lt;agencyName&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agency Name</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1303,11 +1301,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-agent">
+                  <div class="leftcol">
+                     <span class="label">Agent</span>  </div>
+                  <div class="content" id="elem-agent">
                      <span class="label">&lt;agent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1468,11 +1465,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-citedRange">
+                  <div class="leftcol">
+                     <span class="label">Cited Range</span>  </div>
+                  <div class="content" id="elem-citedRange">
                      <span class="label">&lt;citedRange&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Cited Range</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1572,11 +1568,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-classification">
+                  <div class="leftcol">
+                     <span class="label">Classification</span>  </div>
+                  <div class="content" id="elem-classification">
                      <span class="label">&lt;classification&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Classification</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1689,11 +1684,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-classifications">
+                  <div class="leftcol">
+                     <span class="label">Classifications</span>  </div>
+                  <div class="content" id="elem-classifications">
                      <span class="label">&lt;classifications&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Classifications</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -1795,11 +1789,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-control">
+                  <div class="leftcol">
+                     <span class="label">Control</span>  </div>
+                  <div class="content" id="elem-control">
                      <span class="label">&lt;control&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Control</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2073,11 +2066,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-conventionDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Convention Declaration</span>  </div>
+                  <div class="content" id="elem-conventionDeclaration">
                      <span class="label">&lt;conventionDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Convention Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2192,11 +2184,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-date">
+                  <div class="leftcol">
+                     <span class="label">Date</span>  </div>
+                  <div class="content" id="elem-date">
                      <span class="label">&lt;date&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2363,11 +2354,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dateRange">
+                  <div class="leftcol">
+                     <span class="label">Date Range</span>  </div>
+                  <div class="content" id="elem-dateRange">
                      <span class="label">&lt;dateRange&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Range</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2499,11 +2489,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-dateSet">
+                  <div class="leftcol">
+                     <span class="label">Date Set</span>  </div>
+                  <div class="content" id="elem-dateSet">
                      <span class="label">&lt;dateSet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2603,11 +2592,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-description">
+                  <div class="leftcol">
+                     <span class="label">Description</span>  </div>
+                  <div class="content" id="elem-description">
                      <span class="label">&lt;description&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2730,11 +2718,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-descriptiveNote">
+                  <div class="leftcol">
+                     <span class="label">Descriptive Note</span>  </div>
+                  <div class="content" id="elem-descriptiveNote">
                      <span class="label">&lt;descriptiveNote&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Descriptive Note</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2830,11 +2817,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eaf">
+                  <div class="leftcol">
+                     <span class="label">Encoded Archival Functions</span>  </div>
+                  <div class="content" id="elem-eaf">
                      <span class="label">&lt;eaf&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Encoded Archival Functions</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -2913,11 +2899,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eventDateTime">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Date and Time</span>  </div>
+                  <div class="content" id="elem-eventDateTime">
                      <span class="label">&lt;eventDateTime&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Date and Time</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3000,11 +2985,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-eventDescription">
+                  <div class="leftcol">
+                     <span class="label">Event Description</span>  </div>
+                  <div class="content" id="elem-eventDescription">
                      <span class="label">&lt;eventDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Event Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3108,11 +3092,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-formattingExtension">
+                  <div class="leftcol">
+                     <span class="label">Formatting Extension</span>  </div>
+                  <div class="content" id="elem-formattingExtension">
                      <span class="label">&lt;formattingExtension&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Formatting Extension</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3169,11 +3152,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-fromDate">
+                  <div class="leftcol">
+                     <span class="label">From Date</span>  </div>
+                  <div class="content" id="elem-fromDate">
                      <span class="label">&lt;fromDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">From Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3353,11 +3335,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionAgent">
+                  <div class="leftcol">
+                     <span class="label">Function Agent</span>  </div>
+                  <div class="content" id="elem-functionAgent">
                      <span class="label">&lt;functionAgent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Agent</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3485,11 +3466,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionAgents">
+                  <div class="leftcol">
+                     <span class="label">Function Agents</span>  </div>
+                  <div class="content" id="elem-functionAgents">
                      <span class="label">&lt;functionAgents&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Agents</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3589,11 +3569,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionDates">
+                  <div class="leftcol">
+                     <span class="label">Function Dates</span>  </div>
+                  <div class="content" id="elem-functionDates">
                      <span class="label">&lt;functionDates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Dates</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3684,11 +3663,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionDescription">
+                  <div class="leftcol">
+                     <span class="label">Function Description</span>  </div>
+                  <div class="content" id="elem-functionDescription">
                      <span class="label">&lt;functionDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3788,11 +3766,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionHistory">
+                  <div class="leftcol">
+                     <span class="label">Function History</span>  </div>
+                  <div class="content" id="elem-functionHistory">
                      <span class="label">&lt;functionHistory&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -3892,11 +3869,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-functionsDescription">
+                  <div class="leftcol">
+                     <span class="label">Functions Description</span>  </div>
+                  <div class="content" id="elem-functionsDescription">
                      <span class="label">&lt;functionsDescription&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Functions Description</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4002,11 +3978,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-identity">
+                  <div class="leftcol">
+                     <span class="label">Identity</span>  </div>
+                  <div class="content" id="elem-identity">
                      <span class="label">&lt;identity&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4145,11 +4120,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-identityId">
+                  <div class="leftcol">
+                     <span class="label">Identity Identifier</span>  </div>
+                  <div class="content" id="elem-identityId">
                      <span class="label">&lt;identityId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4271,11 +4245,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-label">
+                  <div class="leftcol">
+                     <span class="label">Label</span>  </div>
+                  <div class="content" id="elem-label">
                      <span class="label">&lt;label&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Label</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4405,11 +4378,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-languageDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Language Declaration</span>  </div>
+                  <div class="content" id="elem-languageDeclaration">
                      <span class="label">&lt;languageDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4505,11 +4477,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-legislation">
+                  <div class="leftcol">
+                     <span class="label">Legislation</span>  </div>
+                  <div class="content" id="elem-legislation">
                      <span class="label">&lt;legislation&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Legislation</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4641,11 +4612,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-legislations">
+                  <div class="leftcol">
+                     <span class="label">Legislations</span>  </div>
+                  <div class="content" id="elem-legislations">
                      <span class="label">&lt;legislations&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Legislations</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4745,11 +4715,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-localTypeDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Local Type Declaration</span>  </div>
+                  <div class="content" id="elem-localTypeDeclaration">
                      <span class="label">&lt;localTypeDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -4863,11 +4832,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceAgency">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Agency</span>  </div>
+                  <div class="content" id="elem-maintenanceAgency">
                      <span class="label">&lt;maintenanceAgency&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Agency</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5006,11 +4974,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceEvent">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event</span>  </div>
+                  <div class="content" id="elem-maintenanceEvent">
                      <span class="label">&lt;maintenanceEvent&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5114,11 +5081,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-maintenanceHistory">
+                  <div class="leftcol">
+                     <span class="label">Maintenance History</span>  </div>
+                  <div class="content" id="elem-maintenanceHistory">
                      <span class="label">&lt;maintenanceHistory&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance History</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5193,11 +5159,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-nameEntry">
+                  <div class="leftcol">
+                     <span class="label">Name Entry</span>  </div>
+                  <div class="content" id="elem-nameEntry">
                      <span class="label">&lt;nameEntry&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Name Entry</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5369,11 +5334,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-nameEntrySet">
+                  <div class="leftcol">
+                     <span class="label">Name Entry Set</span>  </div>
+                  <div class="content" id="elem-nameEntrySet">
                      <span class="label">&lt;nameEntrySet&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Name Entry Set</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5490,11 +5454,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-objectXMLWrap">
+                  <div class="leftcol">
+                     <span class="label">Object XML Wrap</span>  </div>
+                  <div class="content" id="elem-objectXMLWrap">
                      <span class="label">&lt;objectXMLWrap&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Object XML Wrap</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5552,11 +5515,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherAgencyCode">
+                  <div class="leftcol">
+                     <span class="label">Other Agency Code</span>  </div>
+                  <div class="content" id="elem-otherAgencyCode">
                      <span class="label">&lt;otherAgencyCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Agency Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5674,11 +5636,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-otherRecordId">
+                  <div class="leftcol">
+                     <span class="label">Other Record Identifier</span>  </div>
+                  <div class="content" id="elem-otherRecordId">
                      <span class="label">&lt;otherRecordId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Other Record Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5787,11 +5748,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-p">
+                  <div class="leftcol">
+                     <span class="label">Paragraph</span>  </div>
+                  <div class="content" id="elem-p">
                      <span class="label">&lt;p&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Paragraph</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -5897,11 +5857,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-part">
+                  <div class="leftcol">
+                     <span class="label">Part</span>  </div>
+                  <div class="content" id="elem-part">
                      <span class="label">&lt;part&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Part</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6009,11 +5968,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-placeName">
+                  <div class="leftcol">
+                     <span class="label">Place Name</span>  </div>
+                  <div class="content" id="elem-placeName">
                      <span class="label">&lt;placeName&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Place Name</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6145,11 +6103,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-recordId">
+                  <div class="leftcol">
+                     <span class="label">Record Identifier</span>  </div>
+                  <div class="content" id="elem-recordId">
                      <span class="label">&lt;recordId&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Record Identifier</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6226,11 +6183,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-reference">
+                  <div class="leftcol">
+                     <span class="label">Reference</span>  </div>
+                  <div class="content" id="elem-reference">
                      <span class="label">&lt;reference&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6376,11 +6332,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-referringString">
+                  <div class="leftcol">
+                     <span class="label">Referring String</span>  </div>
+                  <div class="content" id="elem-referringString">
                      <span class="label">&lt;referringString&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referring String</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6529,11 +6484,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relation">
+                  <div class="leftcol">
+                     <span class="label">Relation</span>  </div>
+                  <div class="content" id="elem-relation">
                      <span class="label">&lt;relation&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6678,11 +6632,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relations">
+                  <div class="leftcol">
+                     <span class="label">Relations</span>  </div>
+                  <div class="content" id="elem-relations">
                      <span class="label">&lt;relations&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relations</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6781,11 +6734,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-relationship">
+                  <div class="leftcol">
+                     <span class="label">Relationship</span>  </div>
+                  <div class="content" id="elem-relationship">
                      <span class="label">&lt;relationship&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relationship</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -6914,11 +6866,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-rightsDeclaration">
+                  <div class="leftcol">
+                     <span class="label">Rights Declaration</span>  </div>
+                  <div class="content" id="elem-rightsDeclaration">
                      <span class="label">&lt;rightsDeclaration&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Rights Declaration</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7030,11 +6981,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-role">
+                  <div class="leftcol">
+                     <span class="label">Role</span>  </div>
+                  <div class="content" id="elem-role">
                      <span class="label">&lt;role&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Role</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7143,11 +7093,10 @@
                   <div class="content"/>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-shortCode">
+                  <div class="leftcol">
+                     <span class="label">Short Code</span>  </div>
+                  <div class="content" id="elem-shortCode">
                      <span class="label">&lt;shortCode&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Short Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7216,11 +7165,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-source">
+                  <div class="leftcol">
+                     <span class="label">Source</span>  </div>
+                  <div class="content" id="elem-source">
                      <span class="label">&lt;source&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7361,11 +7309,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-sources">
+                  <div class="leftcol">
+                     <span class="label">Sources</span>  </div>
+                  <div class="content" id="elem-sources">
                      <span class="label">&lt;sources&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Sources</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7446,11 +7393,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-span">
+                  <div class="leftcol">
+                     <span class="label">span</span>  </div>
+                  <div class="content" id="elem-span">
                      <span class="label">&lt;span&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">span</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7563,11 +7509,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-toDate">
+                  <div class="leftcol">
+                     <span class="label">To Date</span>  </div>
+                  <div class="content" id="elem-toDate">
                      <span class="label">&lt;toDate&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">To Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7727,11 +7672,10 @@
                   </div>
                </div>
                <div class="element">
-                  <div class="leftcol" id="elem-useDates">
+                  <div class="leftcol">
+                     <span class="label">Dates of Use</span>  </div>
+                  <div class="content" id="elem-useDates">
                      <span class="label">&lt;useDates&gt;</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Dates of Use</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7824,11 +7768,10 @@
             <div class="section" id="d1e6058">
                <div class="head03">Attributes</div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-agentType">
+                  <div class="leftcol">
+                     <span class="label">Agent Type</span>  </div>
+                  <div class="content" id="attr-agentType">
                      <span class="label">@agentType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7850,11 +7793,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-agentTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Agent Type Encoding</span>  </div>
+                  <div class="content" id="attr-agentTypeEncoding">
                      <span class="label">@agentTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Agent Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7876,11 +7818,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-audience">
+                  <div class="leftcol">
+                     <span class="label">Audience</span>  </div>
+                  <div class="content" id="attr-audience">
                      <span class="label">@audience</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Audience</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7900,11 +7841,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-audienceEncoding">
+                  <div class="leftcol">
+                     <span class="label">Audience Encoding</span>  </div>
+                  <div class="content" id="attr-audienceEncoding">
                      <span class="label">@audienceEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Audience Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7926,11 +7866,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-calendar">
+                  <div class="leftcol">
+                     <span class="label">Calendar</span>  </div>
+                  <div class="content" id="attr-calendar">
                      <span class="label">@calendar</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Calendar</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7952,11 +7891,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-certainty">
+                  <div class="leftcol">
+                     <span class="label">Certainty</span>  </div>
+                  <div class="content" id="attr-certainty">
                      <span class="label">@certainty</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Certainty</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -7980,11 +7918,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-conventionDeclarationReference">
+                  <div class="leftcol">
+                     <span class="label">Convention Declaration Reference</span>  </div>
+                  <div class="content" id="attr-conventionDeclarationReference">
                      <span class="label">@conventionDeclarationReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Convention Declaration Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8012,11 +7949,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-countryCode">
+                  <div class="leftcol">
+                     <span class="label">Country Code</span>  </div>
+                  <div class="content" id="attr-countryCode">
                      <span class="label">@countryCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Country Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8035,11 +7971,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-countryEncoding">
+                  <div class="leftcol">
+                     <span class="label">Country Encoding</span>  </div>
+                  <div class="content" id="attr-countryEncoding">
                      <span class="label">@countryEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Country Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8062,11 +7997,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-dateEncoding">
+                  <div class="leftcol">
+                     <span class="label">Date Encoding</span>  </div>
+                  <div class="content" id="attr-dateEncoding">
                      <span class="label">@dateEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Date Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8089,11 +8023,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-detailLevel">
+                  <div class="leftcol">
+                     <span class="label">Level of Detail</span>  </div>
+                  <div class="content" id="attr-detailLevel">
                      <span class="label">@detailLevel</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Level of Detail</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8113,11 +8046,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-detailLevelEncoding">
+                  <div class="leftcol">
+                     <span class="label">Detail Level Encoding</span>  </div>
+                  <div class="content" id="attr-detailLevelEncoding">
                      <span class="label">@detailLevelEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Detail Level Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8139,11 +8071,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-era">
+                  <div class="leftcol">
+                     <span class="label">Era</span>  </div>
+                  <div class="content" id="attr-era">
                      <span class="label">@era</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Era</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8164,11 +8095,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-functionStatus">
+                  <div class="leftcol">
+                     <span class="label">Function Status</span>  </div>
+                  <div class="content" id="attr-functionStatus">
                      <span class="label">@functionStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8190,11 +8120,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-functionStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Function Status Encoding</span>  </div>
+                  <div class="content" id="attr-functionStatusEncoding">
                      <span class="label">@functionStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Function Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8216,11 +8145,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-href">
+                  <div class="leftcol">
+                     <span class="label">Hypertext Reference</span>  </div>
+                  <div class="content" id="attr-href">
                      <span class="label">@href</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Hypertext Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8243,11 +8171,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-id">
+                  <div class="leftcol">
+                     <span class="label">ID</span>  </div>
+                  <div class="content" id="attr-id">
                      <span class="label">@id</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">ID</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8271,11 +8198,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-identityType">
+                  <div class="leftcol">
+                     <span class="label">Identity Type</span>  </div>
+                  <div class="content" id="attr-identityType">
                      <span class="label">@identityType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8292,11 +8218,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-identityTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Identity Type Encoding</span>  </div>
+                  <div class="content" id="attr-identityTypeEncoding">
                      <span class="label">@identityTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Identity Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8318,11 +8243,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageCode">
+                  <div class="leftcol">
+                     <span class="label">Language Code</span>  </div>
+                  <div class="content" id="attr-languageCode">
                      <span class="label">@languageCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8341,11 +8265,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageEncoding">
+                  <div class="leftcol">
+                     <span class="label">Language Encoding</span>  </div>
+                  <div class="content" id="attr-languageEncoding">
                      <span class="label">@languageEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8368,11 +8291,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-languageOfElement">
+                  <div class="leftcol">
+                     <span class="label">Language of Element</span>  </div>
+                  <div class="content" id="attr-languageOfElement">
                      <span class="label">@languageOfElement</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Language of Element</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8392,11 +8314,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-linkRole">
+                  <div class="leftcol">
+                     <span class="label">Link Role</span>  </div>
+                  <div class="content" id="attr-linkRole">
                      <span class="label">@linkRole</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Link Role</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8418,11 +8339,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-linkTitle">
+                  <div class="leftcol">
+                     <span class="label">Link Title</span>  </div>
+                  <div class="content" id="attr-linkTitle">
                      <span class="label">@linkTitle</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Link Title</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8445,11 +8365,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-localType">
+                  <div class="leftcol">
+                     <span class="label">Local Type</span>  </div>
+                  <div class="content" id="attr-localType">
                      <span class="label">@localType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8482,11 +8401,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-localTypeDeclarationReference">
+                  <div class="leftcol">
+                     <span class="label">Local Type Declaration Reference</span>  </div>
+                  <div class="content" id="attr-localTypeDeclarationReference">
                      <span class="label">@localTypeDeclarationReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Local Type Declaration Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8511,11 +8429,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventReference">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Reference</span>  </div>
+                  <div class="content" id="attr-maintenanceEventReference">
                      <span class="label">@maintenanceEventReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8536,11 +8453,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventType">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Type</span>  </div>
+                  <div class="content" id="attr-maintenanceEventType">
                      <span class="label">@maintenanceEventType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8562,11 +8478,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceEventTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Event Type Encoding</span>  </div>
+                  <div class="content" id="attr-maintenanceEventTypeEncoding">
                      <span class="label">@maintenanceEventTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Event Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8588,11 +8503,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceStatus">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Status</span>  </div>
+                  <div class="content" id="attr-maintenanceStatus">
                      <span class="label">@maintenanceStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8611,11 +8525,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-maintenanceStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Maintenance Status Encoding</span>  </div>
+                  <div class="content" id="attr-maintenanceStatusEncoding">
                      <span class="label">@maintenanceStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Maintenance Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8637,11 +8550,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-normalizedForm">
+                  <div class="leftcol">
+                     <span class="label">Normalized Form</span>  </div>
+                  <div class="content" id="attr-normalizedForm">
                      <span class="label">@normalizedForm</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Normalized Form</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8660,11 +8572,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-notAfter">
+                  <div class="leftcol">
+                     <span class="label">Not After</span>  </div>
+                  <div class="content" id="attr-notAfter">
                      <span class="label">@notAfter</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Not After</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8683,11 +8594,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-notBefore">
+                  <div class="leftcol">
+                     <span class="label">Not Before</span>  </div>
+                  <div class="content" id="attr-notBefore">
                      <span class="label">@notBefore</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Not Before</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8706,11 +8616,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-preferredForm">
+                  <div class="leftcol">
+                     <span class="label">Preferred Form</span>  </div>
+                  <div class="content" id="attr-preferredForm">
                      <span class="label">@preferredForm</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Preferred Form</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8732,11 +8641,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-publicationStatus">
+                  <div class="leftcol">
+                     <span class="label">Publication Status</span>  </div>
+                  <div class="content" id="attr-publicationStatus">
                      <span class="label">@publicationStatus</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8758,11 +8666,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-publicationStatusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Publication Status Encoding</span>  </div>
+                  <div class="content" id="attr-publicationStatusEncoding">
                      <span class="label">@publicationStatusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Publication Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8784,11 +8691,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityRelationship">
+                  <div class="leftcol">
+                     <span class="label">Referred Entity Relationship</span>  </div>
+                  <div class="content" id="attr-referredEntityRelationship">
                      <span class="label">@referredEntityRelationship</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referred Entity Relationship</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8806,11 +8712,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityType">
+                  <div class="leftcol">
+                     <span class="label">Referrered Entity Type</span>  </div>
+                  <div class="content" id="attr-referredEntityType">
                      <span class="label">@referredEntityType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referrered Entity Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8832,11 +8737,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-referredEntityTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Referred Entity Type Encoding</span>  </div>
+                  <div class="content" id="attr-referredEntityTypeEncoding">
                      <span class="label">@referredEntityTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Referred Entity Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8858,11 +8762,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-relationType">
+                  <div class="leftcol">
+                     <span class="label">Relation Type</span>  </div>
+                  <div class="content" id="attr-relationType">
                      <span class="label">@relationType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8884,11 +8787,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-relationTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Relation Type Encoding</span>  </div>
+                  <div class="content" id="attr-relationTypeEncoding">
                      <span class="label">@relationTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Relation Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8910,11 +8812,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-repositoryEncoding">
+                  <div class="leftcol">
+                     <span class="label">Repository Encoding</span>  </div>
+                  <div class="content" id="attr-repositoryEncoding">
                      <span class="label">@repositoryEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Repository Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8937,11 +8838,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptCode">
+                  <div class="leftcol">
+                     <span class="label">Script Code</span>  </div>
+                  <div class="content" id="attr-scriptCode">
                      <span class="label">@scriptCode</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script Code</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8960,11 +8860,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptEncoding">
+                  <div class="leftcol">
+                     <span class="label">Script Encoding</span>  </div>
+                  <div class="content" id="attr-scriptEncoding">
                      <span class="label">@scriptEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -8986,11 +8885,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-scriptOfElement">
+                  <div class="leftcol">
+                     <span class="label">Script of Element</span>  </div>
+                  <div class="content" id="attr-scriptOfElement">
                      <span class="label">@scriptOfElement</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Script of Element</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9011,11 +8909,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-sourceReference">
+                  <div class="leftcol">
+                     <span class="label">Source Reference</span>  </div>
+                  <div class="content" id="attr-sourceReference">
                      <span class="label">@sourceReference</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Source Reference</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9038,11 +8935,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-standardDate">
+                  <div class="leftcol">
+                     <span class="label">Standard Date</span>  </div>
+                  <div class="content" id="attr-standardDate">
                      <span class="label">@standardDate</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Standard Date</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9063,11 +8959,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-standardDateTime">
+                  <div class="leftcol">
+                     <span class="label">Standard Date and Time</span>  </div>
+                  <div class="content" id="attr-standardDateTime">
                      <span class="label">@standardDateTime</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Standard Date and Time</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9095,11 +8990,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-status">
+                  <div class="leftcol">
+                     <span class="label">Status</span>  </div>
+                  <div class="content" id="attr-status">
                      <span class="label">@status</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Status</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9122,11 +9016,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-statusEncoding">
+                  <div class="leftcol">
+                     <span class="label">Status Encoding</span>  </div>
+                  <div class="content" id="attr-statusEncoding">
                      <span class="label">@statusEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Status Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9152,11 +9045,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-style">
+                  <div class="leftcol">
+                     <span class="label">Style</span>  </div>
+                  <div class="content" id="attr-style">
                      <span class="label">@style</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Style</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9175,11 +9067,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-target">
+                  <div class="leftcol">
+                     <span class="label">Target</span>  </div>
+                  <div class="content" id="attr-target">
                      <span class="label">@target</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9198,11 +9089,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-targetType">
+                  <div class="leftcol">
+                     <span class="label">Target Type</span>  </div>
+                  <div class="content" id="attr-targetType">
                      <span class="label">@targetType</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target Type</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9224,11 +9114,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-targetTypeEncoding">
+                  <div class="leftcol">
+                     <span class="label">Target Type Encoding</span>  </div>
+                  <div class="content" id="attr-targetTypeEncoding">
                      <span class="label">@targetTypeEncoding</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Target Type Encoding</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9250,11 +9139,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-unit">
+                  <div class="leftcol">
+                     <span class="label">Unit</span>  </div>
+                  <div class="content" id="attr-unit">
                      <span class="label">@unit</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Unit</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9275,11 +9163,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-valueURI">
+                  <div class="leftcol">
+                     <span class="label">Value URI</span>  </div>
+                  <div class="content" id="attr-valueURI">
                      <span class="label">@valueURI</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Value URI</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9301,11 +9188,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-vocabularySource">
+                  <div class="leftcol">
+                     <span class="label">Vocabulary Source</span>  </div>
+                  <div class="content" id="attr-vocabularySource">
                      <span class="label">@vocabularySource</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Vocabulary Source</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">
@@ -9326,11 +9212,10 @@
                </div>
                <div class="spacer"> </div>
                <div class="attribute">
-                  <div class="leftcol" id="attr-vocabularySourceURI">
+                  <div class="leftcol">
+                     <span class="label">Vocabulary Source URI</span>  </div>
+                  <div class="content" id="attr-vocabularySourceURI">
                      <span class="label">@vocabularySourceURI</span>
-                  </div>
-                  <div class="content">
-                     <span class="label">Vocabulary Source URI</span>  <a class="tocReturn" href="#toc">[toc]</a>
                   </div>
                   <div class="leftcol">Summary: </div>
                   <div class="content">

--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -519,9 +519,19 @@
 
         <xsl:template match="tei:head/tei:gi">
                 <!-- Karin: Changes needed to be made here to get it to write semmantic unit when head has type=DD -->
+
+                <div class="leftcol">
+                        <span class="label"> 
+                                <xsl:value-of
+                                        select="ancestor-or-self::tei:div[@type='elementDocumentation']/tei:div[@type='fullName']/tei:p"
+                                />  
+                     </span>
+                        <xsl:text>&#xA0;&#xA0;</xsl:text>
+                        <!--a class="tocReturn" href="#toc">[toc]</a-->
+                </div>
                 <xsl:choose>
                         <xsl:when test="ancestor-or-self::tei:front">
-                                <div class="leftcol" id="{generate-id()}">
+                                <div class="content" id="{generate-id()}">
                                         <span class="label">
                                                 <xsl:text>&lt;</xsl:text>
                                                 <xsl:apply-templates/>
@@ -530,7 +540,7 @@
                                 </div>
                         </xsl:when>
                         <xsl:otherwise>
-                                <div class="leftcol" id="{translate(concat('elem-', .), ':','')}">
+                                <div class="content" id="{translate(concat('elem-', .), ':','')}">
                                         <span class="label">
                                                 <!-- would like to look into this section, but for now just removing the PREMIS bit.  - mdc -->
                                                 <xsl:text>&lt;</xsl:text>
@@ -540,15 +550,6 @@
                                 </div>
                         </xsl:otherwise>
                 </xsl:choose>
-                <div class="content">
-                        <span class="label"> 
-                                <xsl:value-of
-                                        select="ancestor-or-self::tei:div[@type='elementDocumentation']/tei:div[@type='fullName']/tei:p"
-                                />  
-                     </span>
-                        <xsl:text>&#xA0;&#xA0;</xsl:text>
-                        <a class="tocReturn" href="#toc">[toc]</a>
-                </div>
         </xsl:template>
 
         <xsl:template match="tei:div[@type='fullName']"/>
@@ -602,20 +603,20 @@
         </xsl:template>
         
         <xsl:template match="tei:head/tei:att">
-                <div class="leftcol" id="{translate(concat('attr-' , .), ':','')}">
-                        <span class="label">
-                                <xsl:text>@</xsl:text>
-                                <xsl:value-of select="."/>
-                        </span>
-                </div>
-                <div class="content">
+                <div class="leftcol">
                         <span class="label"> 
                                 <xsl:value-of
                                         select="ancestor-or-self::tei:div[@type='attributeDocumentation']/tei:div[@type='fullName']/tei:p"
                                 />
                         </span>
                         <xsl:text>&#xA0;&#xA0;</xsl:text>
-                        <a class="tocReturn" href="#toc">[toc]</a>
+                        <!--a class="tocReturn" href="#toc">[toc]</a-->
+                </div>
+                <div class="content" id="{translate(concat('attr-' , .), ':','')}">
+                        <span class="label">
+                                <xsl:text>@</xsl:text>
+                                <xsl:value-of select="."/>
+                        </span>
                 </div>
         </xsl:template>
         

--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -627,7 +627,7 @@
                         <xsl:text>: </xsl:text>
                 </div>
                     <div class="content">
-                        <xsl:apply-templates/>
+                        <xsl:apply-templates select="tei:p | tei:list"/>
                     </div>
         </xsl:template>
         

--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -621,14 +621,21 @@
         </xsl:template>
         
         <xsl:template match="tei:div[@type=('summary', 'definition', 'entity', 'rationale', 'creationmaintenance', 'usagenotes', 'description', 'desc', 'usage', 'attributeusage', 'seealso', 'examples')]">
-                <div class="leftcol">
-                        <xsl:variable name="termtitle"><xsl:value-of select="current()/@type"/></xsl:variable>
-                        <xsl:value-of select="$headingtranslations/*:terms/*:term[@name=$termtitle]/*:translation[@lang=$currentLanguage]"/>
-                        <xsl:text>: </xsl:text>
-                </div>
-                    <div class="content">
-                        <xsl:apply-templates select="tei:p | tei:list"/>
+            <xsl:choose>
+                <xsl:when test="tei:p[@type=$currentStandard] | tei:p[not(@type)]">                
+                    <div class="leftcol">
+                            <xsl:variable name="termtitle"><xsl:value-of select="current()/@type"/></xsl:variable>
+                            <xsl:value-of select="$headingtranslations/*:terms/*:term[@name=$termtitle]/*:translation[@lang=$currentLanguage]"/>
+                            <xsl:text>: </xsl:text>
                     </div>
+                        <div class="content">
+                            <xsl:apply-templates/>
+                        </div>
+                        </xsl:when>
+                        <xsl:otherwise>
+                    <xsl:text></xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:template>
         
         <!-- leftcol + content elements -->


### PR DESCRIPTION
Element/attribute names in HTML could run outside of the left column (e.g. `@descriptionOfComponentsTypeEncoding`).  This swaps the title and label, since the labels will flow properly in the smaller column.

This PR also removes Example headings when no example is present.