### PR TITLE
Update EAC-CPF XML schema path to only v3

### DIFF
--- a/tei/EAC-CPF3-TL-eng.xml
+++ b/tei/EAC-CPF3-TL-eng.xml
@@ -497,7 +497,7 @@
     		<div type="appendix" xml:id="appendix1">
     			<head>Examples</head>
                 <div type="exampleText" subtype="eac">
-                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3 https://github.com/SAA-SDT/eas-schemas/releases/download/EAC-CPF3.0.0/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3">
+                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3 https://github.com/SAA-SDT/eas-schemas/tree/release_2026_07/xml-schemas/eac-cpf/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3">
 	<control addressLineTypeEncoding="EASList" agentTypeEncoding="EASList" audienceEncoding="EASList" contactLineTypeEncoding="EASList" countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" identityTypeEncoding="EASList" languageEncoding="iso639-2b" maintenanceStatus="revised" maintenanceEventTypeEncoding="EASList" maintenanceStatusEncoding="EASList" placeTypeEncoding="EASList" publicationStatus="published" publicationStatusEncoding="EASList" referredEntityTypeEncoding="EASList" relationTypeEncoding="EASList" repositoryEncoding="iso15511" scriptEncoding="iso15924" scriptOfElement="Latn" targetTypeEncoding="EASList" statusEncoding="EASList">
 		<recordId>
 			21159483
@@ -536,7 +536,7 @@
 	</cpfDescription>
 </eac>]]>
                     </egXML>
-                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3 https://github.com/SAA-SDT/eas-schemas/releases/download/EAC-CPF3.0.0/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3">
+                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3 https://github.com/SAA-SDT/eas-schemas/tree/release_2026_07/xml-schemas/eac-cpf/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3">
 	<control addressLineTypeEncoding="EASList" agentTypeEncoding="EASList" audienceEncoding="EASList" contactLineTypeEncoding="EASList" countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" identityTypeEncoding="EASList" languageEncoding="iso639-2b" maintenanceStatus="revised" maintenanceEventTypeEncoding="EASList" maintenanceStatusEncoding="EASList" placeTypeEncoding="EASList" publicationStatus="published" publicationStatusEncoding="EASList" referredEntityTypeEncoding="EASList" relationTypeEncoding="EASList" repositoryEncoding="iso15511" scriptEncoding="iso15924" scriptOfElement="Latn" targetTypeEncoding="EASList" statusEncoding="EASList">
 		<recordId>
 		   EACexampleMI

--- a/tei/EAC-CPF3-TL-eng.xml
+++ b/tei/EAC-CPF3-TL-eng.xml
@@ -497,7 +497,7 @@
     		<div type="appendix" xml:id="appendix1">
     			<head>Examples</head>
                 <div type="exampleText" subtype="eac">
-                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3.0.0 https://github.com/SAA-SDT/eas-schemas/releases/download/EAC-CPF3.0.0/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3.0.0">
+                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3 https://github.com/SAA-SDT/eas-schemas/releases/download/EAC-CPF3.0.0/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3">
 	<control addressLineTypeEncoding="EASList" agentTypeEncoding="EASList" audienceEncoding="EASList" contactLineTypeEncoding="EASList" countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" identityTypeEncoding="EASList" languageEncoding="iso639-2b" maintenanceStatus="revised" maintenanceEventTypeEncoding="EASList" maintenanceStatusEncoding="EASList" placeTypeEncoding="EASList" publicationStatus="published" publicationStatusEncoding="EASList" referredEntityTypeEncoding="EASList" relationTypeEncoding="EASList" repositoryEncoding="iso15511" scriptEncoding="iso15924" scriptOfElement="Latn" targetTypeEncoding="EASList" statusEncoding="EASList">
 		<recordId>
 			21159483
@@ -536,7 +536,7 @@
 	</cpfDescription>
 </eac>]]>
                     </egXML>
-                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3.0.0 https://github.com/SAA-SDT/eas-schemas/releases/download/EAC-CPF3.0.0/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3.0.0">
+                    <egXML xml:lang="eng"><![CDATA[<eac xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://standards.openpreservation.org/eac/v3 https://github.com/SAA-SDT/eas-schemas/releases/download/EAC-CPF3.0.0/eac.xsd" xmlns="https://standards.openpreservation.org/eac/v3">
 	<control addressLineTypeEncoding="EASList" agentTypeEncoding="EASList" audienceEncoding="EASList" contactLineTypeEncoding="EASList" countryEncoding="iso3166-1-alpha-2" dateEncoding="iso8601" identityTypeEncoding="EASList" languageEncoding="iso639-2b" maintenanceStatus="revised" maintenanceEventTypeEncoding="EASList" maintenanceStatusEncoding="EASList" placeTypeEncoding="EASList" publicationStatus="published" publicationStatusEncoding="EASList" referredEntityTypeEncoding="EASList" relationTypeEncoding="EASList" repositoryEncoding="iso15511" scriptEncoding="iso15924" scriptOfElement="Latn" targetTypeEncoding="EASList" statusEncoding="EASList">
 		<recordId>
 		   EACexampleMI


### PR DESCRIPTION
The namespace is: https://standards.openpreservation.org/eac/v3