### PR TITLE
simplying egXML generation in pdf

### DIFF
--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -983,17 +983,20 @@
         </xsl:template>
 
     <xsl:template match="tei:div[@type='exampleText']">
-	        <xsl:variable name="exampleType" select="current()/@subtype"/>
+        <xsl:variable name="exampleType" select="current()/@subtype"/>
         <div class="head04" id="{concat('example-', $exampleType)}">
             <xsl:value-of select="$exampleType"/>
         </div>
         <div type="example">
-            <pre>
-                <xsl:value-of select="."/>
-            </pre>
+            <xsl:apply-templates/>
         </div>
     </xsl:template>
         
+    <xsl:template match="tei:egXML">
+        <pre>
+            <xsl:apply-templates/>
+        </pre>
+    </xsl:template>
         <!-- total hack until we determine how best to hande this. but, we don't want to wind up with "LibraryVersion", which is what we have now. -->
         <xsl:template match="tei:titlePart">
                 <xsl:apply-templates/>

--- a/transformations/tagLibrary2pdf.xsl
+++ b/transformations/tagLibrary2pdf.xsl
@@ -1183,25 +1183,20 @@
     </xsl:template>
 
     <xsl:template match="tei:div[@type = 'exampleText']"> 
-		     <fo:block role="H3" font-weight="bold" space-after="1em" space-before="1em" font-size="1.17em">
+            <fo:block role="H3" font-weight="bold" space-after="1em" space-before="1em" font-size="1.17em">
                 <xsl:attribute name="id" select="concat('example-', @subtype)"/>
                 <xsl:value-of select="@subtype"/>
-             </fo:block>
-             <xsl:choose>
-                <xsl:when test="egXML">
-                   <xsl:for-each select="egXML[@type=$currentStandard] | egXML[not(@type)]">
-                       <fo:block font-family="KurintoMono,KurintoMonoJP,KurintoMonoKR,KurintoMonoSC" white-space-collapse="false" text-align="start" wrap-option="wrap" linefeed-treatment="preserve" white-space-treatment="preserve" background-color="gainsboro" border="outset" font-size="0.83em" padding="2mm" margin="0mm" space-after="3mm">
-                          <xsl:value-of select="."/>
-                       </fo:block>
-                    </xsl:for-each>
-                 </xsl:when>
-                 <xsl:otherwise>
-                    <fo:block>
-                       <xsl:apply-templates/>
-                    </fo:block>
-                 </xsl:otherwise>
-              </xsl:choose>
+            </fo:block>
+            <xsl:apply-templates/>
     </xsl:template>
+
+    <xsl:template match="egXML">
+        <fo:block font-family="KurintoMono,KurintoMonoJP,KurintoMonoKR,KurintoMonoSC" white-space-collapse="false" text-align="start" wrap-option="wrap" linefeed-treatment="preserve" white-space-treatment="preserve" background-color="gainsboro" border="outset" font-size="0.83em" padding="2mm" margin="0mm" space-after="3mm">
+            <xsl:value-of select="."/>
+        </fo:block>
+    </xsl:template>
+
+
     <!-- In this template all occuring other namespaceprefixis needs to be added -->
     <xsl:template
         match="eac-cpf:* | eac:* |example:* | ead:* | ead3:* | eaf:*| mods:* | text:* | dc:* | oai_dc:* | premis:*">


### PR DESCRIPTION
This change simplifies how examples are generated in PDFs, which allows for non-egXML content in appendices.  This resolves the issue in EAF where the non-egXML content was being dropped.