### PR TITLE
Add announcement for EAS Suite release

### DIFF
--- a/docs/news/20260706.md
+++ b/docs/news/20260706.md
@@ -1,0 +1,9 @@
+# EAS Suite release ahead (20260706)
+The brand-new versions of EAD 4 and EAC-CPF 3 and the new standard EAC-F (Encoded Archival Context-Functions) will be formally released by SAA’s Technical Subcommittee for Encoded Archival Standards (TS-EAS) at a session on the 31st of July 2026 during the 90th Annual Meeting of the Society of American Archivists https://www2.archivists.org/am2022/ . This session is a hybrid session that all those attending in person and virtually can participate. The session will introduce the Encoded Archival Standards (EAS) Suite and all its components. It will also answer questions about how the standards work together, and provide participants with answers to the Who, Why and What of records. 
+* Who: The EAC-CPF describing the creator
+* Why: The EAC-F’s describing the function and/or activities which results in a record being created
+* What: The EAD where all the records are described
+
+Finally, the session will provide guidance for how one can get started right away using the new standards.  
+
+  After the Annual Meeting, a broader announcement will follow, providing links to all the relevant documentation for the suite of standards.


### PR DESCRIPTION
This document announces the upcoming release of EAD 4 and EAC-CPF 3, along with the new EAC-F standard, during the SAA's 90th Annual Meeting.